### PR TITLE
Bind to all network interfaces (was: only localhost)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -209,9 +209,10 @@ async function bootstrap() {
 
     // Start or update server
     if (!server) {
-      server = ViteExpress.listen(app, PORT, () => {
-        console.log(`🎉server start on port http://localhost:${PORT} - env: ${process.env.NODE_ENV || 'development'}`);
-      });
+      const server = app.listen(PORT, "0.0.0.0", () =>
+        console.log(`🎉server start on port http://0.0.0.0:${PORT} - env: ${process.env.NODE_ENV || 'development'}`);
+      );
+      ViteExpress.bind(app, server); // the server binds to all network interfaces
     } else {
       console.log(`API routes updated - env: ${process.env.NODE_ENV || 'development'}`);
     }
@@ -220,9 +221,10 @@ async function bootstrap() {
     try {
       // Attempt to start server even if route setup fails
       if (!server) {
-        server = ViteExpress.listen(app, PORT, () => {
-          console.log(`🎉server start on port http://localhost:${PORT} - env: ${process.env.NODE_ENV || 'development'}`);
-        });
+        const server = app.listen(PORT, "0.0.0.0", () =>
+          console.log(`🎉server start on port http://0.0.0.0:${PORT} - env: ${process.env.NODE_ENV || 'development'}`);
+        );
+        ViteExpress.bind(app, server); // the server binds to all network interfaces
       }
     } catch (startupError) {
       console.error('start server error:', startupError);


### PR DESCRIPTION
The server now binds to all network interfaces (`0.0.0.0`) instead of only `localhost`. See https://www.npmjs.com/package/vite-express?activeTab=readme for details.