### PR TITLE
Fix service worker caching and enhance OAuth state security

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
       manifest: false,
       workbox: {
         maximumFileSizeToCacheInBytes: 10 * 1024 * 1024,
+        navigateFallbackDenylist: [/^\/api\/auth\/.*/],
       }
     })
   ],

--- a/server/routerExpress/auth/index.ts
+++ b/server/routerExpress/auth/index.ts
@@ -205,7 +205,8 @@ router.get('/:providerId', logOAuthRequest('Custom'), (req, res, next) => {
   }
   
   passport.authenticate(providerId, {
-    scope: ['openid', 'profile', 'email']
+    scope: ['openid', 'profile', 'email'],
+    state: Math.random().toString(36).substring(2, 12)
   })(req, res, next);
 });
 


### PR DESCRIPTION
**Changes**:  
1. Service Worker Configuration  
   - Added `navigateFallbackDenylist` to exclude auth API routes from caching  
   - Prevents service worker from intercepting `/api/auth/` endpoints  

2. OAuth State Parameter Fix  
   - Implemented explicit state generation with 10-character random string  
   - Uses `Math.random().toString(36).substring(2, 12)` for sufficient entropy  
   - Meets Authelia's minimum 8-character state requirement  

This PR can fix the issue where I couldn't log in through Authelia on my Blinko instance, though it might also resolve #670.