### PR TITLE
Docs: add Run on CLAWCLOUD button

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@
 
 [![Run on PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=blinko)
 
+[![](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?openapp=system-fastdeploy%3FtemplateName%3Dblinko)
+
 Blinko is an innovative open-source project designed for individuals who want to quickly capture and organize their fleeting thoughts. Blinko allows users to seamlessly jot down ideas the moment they strike, ensuring that no spark of creativity is lost.
 
 <img style="border-radius:20px" src="./app/public/home.webp" alt="Blinko" />
@@ -70,5 +72,4 @@ If you find Blinko valuable, consider supporting us! Your contribution will enab
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=blinko-space/blinko&type=Date)](https://star-history.com/#blinko-space/blinko&Date)
-
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,6 +27,8 @@
 
 [![Run on PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=blinko)
 
+[![](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?openapp=system-fastdeploy%3FtemplateName%3Dblinko)
+
 Blinko 是一个创新的开源项目，专为那些想要快速捕捉和组织灵感的人设计。它允许用户在灵感闪现的瞬间无缝记录想法，确保不错过任何创意火花。
 
 <img style="border-radius:20px" src="./app/public/home.webp" alt="Blinko" />


### PR DESCRIPTION
Add **ClawCloud Run Deploy Button** to provide Blinko users with:

- **Zero-configuration quick start** – Instantly launch a production-ready Blinko instance without needing a server or domain name
- **Free trial environment** – Get $5 in free account credits every month to deploy and run Blinko reliably on ClawCloud Run
- **Native integrated experience** – Database and storage are automatically configured for a seamless out-of-the-box experience
- **Low-barrier onboarding** – Reduce the cost for new users to try Blinko and boost project adoption