### PR TITLE
fix: navigateFallbackDenylist `/api/*`

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
         manifest: false,
         workbox: {
           maximumFileSizeToCacheInBytes: 10 * 1024 * 1024,
-          navigateFallbackDenylist: [/^\/api\/auth\/.*/],
+          navigateFallbackDenylist: [/^\/api\/.*/],
         }
       })
     ] : [])


### PR DESCRIPTION
The /api/file/* path is currently intercepted by the service worker, which is causing several issues. It should be excluded from the service worker's scope.