### PR TITLE
fix: #802

### DIFF
--- a/server/routerTrpc/user.ts
+++ b/server/routerTrpc/user.ts
@@ -546,6 +546,22 @@ export const userRouter = router({
           where: { userId: id }
         })
 
+        await prisma.noteInternalShare.deleteMany({
+          where: { accountId: id }
+        })
+
+        await prisma.follows.deleteMany({
+          where: { accountId: id }
+        })
+
+        await prisma.notifications.deleteMany({
+          where: { accountId: id }
+        })
+
+        await prisma.conversation.deleteMany({
+          where: { accountId: id }
+        })
+
         await prisma.accounts.delete({
           where: { id }
         })


### PR DESCRIPTION
There's a foreign key constraint error when trying to delete an account. The error indicates that there are still references to the account in the noteInternalShare table via the accountId_fkey constraint.