### PR TITLE
feat(app): optimize AI query processing for global search

### DIFF
--- a/app/src/components/Layout/GlobalSearch.tsx
+++ b/app/src/components/Layout/GlobalSearch.tsx
@@ -196,6 +196,11 @@ export const GlobalSearch = observer(({ isOpen, onOpenChange }: GlobalSearchProp
       blinkoStore.globalSearchTerm = query;
 
       try {
+        // Ensure AI retrieval flag is in sync for this call
+        // Detect "@" prefix proactively to avoid timing issues with the effect
+        const isAiQuery = query.trim().startsWith('@') || store.isAiQuestion;
+        blinkoStore.noteListFilterConfig.isUseAiQuery = isAiQuery;
+
         // 2. Search for notes using the API
         // Set search text in the store and call the API through the store
         blinkoStore.searchText = query;
@@ -205,7 +210,8 @@ export const GlobalSearch = observer(({ isOpen, onOpenChange }: GlobalSearchProp
         const resources = await blinkoStore.resourceList.resetAndCall({
           page: 1,
           size: 20,
-          searchText: query,
+          // Strip leading @/# so regular resource search still works with prefixes
+          searchText: query.replace(/^[@#]/, ''),
           folder: undefined,
         });
 


### PR DESCRIPTION
当前在blinko主界面通过ctrl+k唤出搜索栏，使用"@关键词"搜索不到内容的bug。
完整的设计逻辑是:直接使用关键词而不添加@符号,表示使用纯关键词对笔记进行搜索;当添加关键词时使用AI搜索,即借助embedding模型进行相似笔记检索，当前该功能是失效的，使用"@关键词"时不会有结果出现，但是在AI对话界面启用知识库搜索时，可以正常检索到笔记并提供给LLM进行回复。

错误原因：
全局搜索模态框在输入以 “@” 开头时，会通过一个副作用设置 AI 搜索标志（isAiQuestion => noteListFilterConfig.isUseAiQuery），但带防抖的搜索可能在该标志应用之前就执行了。这导致 “@查询内容” 退回到纯文本搜索（会尝试匹配字面意义上的 “@”），从而返回无结果。

所作修改：
在 app/src/components/Layout/GlobalSearch.tsx 中，就在触发搜索之前同步设置 AI 标志：
通过 query.trim ().startsWith ('@') || store.isAiQuestion 检测 “@”。
就在 blinkoStore.noteList.resetAndCall 之前，设置 blinkoStore.noteListFilterConfig.isUseAiQuery = isAiQuery；
还对资源搜索进行了清理，去除开头的 “@” 或 “#”，以便附件搜索能在带前缀的查询下正常工作：
searchText: query.replace(/^[@#]/, '')

Fixed by Codex