### PR TITLE
fix: prevent empty string being sent to embeddings API

### DIFF
--- a/server/routerTrpc/note.ts
+++ b/server/routerTrpc/note.ts
@@ -106,11 +106,16 @@ export const noteRouter = router({
     .mutation(async function ({ input, ctx }) {
       const { tagId, type, isArchived, isRecycle, searchText, page, size, orderBy, withFile, withoutTag, withLink, isUseAiQuery, startDate, endDate, isShare, hasTodo } = input;
       if (isUseAiQuery && searchText?.trim() != '') {
-        if (page == 1) {
-          return await AiService.enhanceQuery({ query: searchText?.replace(/@/g, '')!, ctx });
-        } else {
-          return [];
+        const cleanedQuery = searchText?.replace(/@/g, '').trim();
+        if (cleanedQuery && cleanedQuery.length > 0) {
+          if (page == 1) {
+            return await AiService.enhanceQuery({ query: cleanedQuery, ctx });
+          } else {
+            return [];
+          }
         }
+        // 如果清理后的查询为空，返回空结果而不是调用AI
+        return [];
       }
 
       let where: Prisma.notesWhereInput = {

--- a/server/routerTrpc/note.ts
+++ b/server/routerTrpc/note.ts
@@ -114,7 +114,6 @@ export const noteRouter = router({
             return [];
           }
         }
-        // 如果清理后的查询为空，返回空结果而不是调用AI
         return [];
       }
 


### PR DESCRIPTION
在容器运行过程中观察到VoyageAI API调用失败的错误日志：

```
Error in enhanceQuery: pN [AI_APICallError]: Bad Request
    at /app/server/index.js:3032:13807
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async K7l (/app/server/index.js:3032:12515)
    at async c$l.doEmbed (/app/server/index.js:3032:75459)
    ...
  cause: undefined,
  url: 'https://api.voyageai.com/v1/embeddings',
  requestBodyValues: {
    input: [ '' ],  // 空字符串导致400错误
    model: 'voyage-3.5',
    input_type: undefined,
    truncation: undefined,
    output_dimension: undefined,
    output_dtype: undefined
  },
  statusCode: 400
```
## 原因分析
在 `server/routerTrpc/note.ts:110` 中：

```typescript
return await AiService.enhanceQuery({
  query: searchText?.replace(/@/g, "")!,
  ctx,
});
```
当用户搜索的文本只包含 `@` 符号时，`replace(/@/g, '')` 会产生空字符串，然后传递给EmbeddingAPI。API拒绝处理空输入，返回400 Bad Request错误。