### PR TITLE
Docs: update French translation of todo to Tâches instead of Procuration

### DIFF
--- a/app/public/locales/fr/translation.json
+++ b/app/public/locales/fr/translation.json
@@ -637,7 +637,7 @@
   "import-from-markdown": "Importer à partir d'un fichier Markdown",
   "import-from-markdown-tip": "Importer à partir d'un simple fichier .md ou d'une archive .zip contenant des fichiers .md",
   "not-a-markdown-or-zip-file": "Ce n'est pas un fichier Markdown ou zip. Veuillez sélectionner un fichier .md ou .zip.",
-  "todo": "Procuration",
+  "todo": "Tâches",
   "restore": "Rétablissement",
   "complete": "terminé",
   "today": "Aujourd'hui",


### PR DESCRIPTION
The French translation for "Todo" was incorrectly set to "Procuration".  
This PR updates it to "Tâches", which is the correct and natural wording for tasks in French.
