### PR TITLE
fix(ai): reset chat state when deleting active conversation

### DIFF
--- a/app/src/components/BlinkoAi/aiConversactionList.tsx
+++ b/app/src/components/BlinkoAi/aiConversactionList.tsx
@@ -35,6 +35,9 @@ export const AiConversactionList = observer(() => {
     await PromiseCall(api.conversation.delete.mutate({
       id: item.id
     }))
+    if (aiStore.currentConversationId === item.id) {
+      aiStore.newChat()
+    }
     aiStore.conversactionList.resetAndCall({})
   }
   return <div className="px-2 pb-6">


### PR DESCRIPTION
Prevent foreign key constraint error by calling newChat() to reset currentConversationId when the deleted conversation is the active one.