### PR TITLE
security: fix IDOR in tag and message routers (Enforce accountId ownership)

### DIFF
--- a/server/routerTrpc/message.ts
+++ b/server/routerTrpc/message.ts
@@ -71,6 +71,7 @@ export const messageRouter = router({
       const message = await prisma.message.findUnique({
         where: {
           id: input.id,
+          accountId: ctx.user.id,
         },
         select: {
           conversationId: true,
@@ -86,6 +87,7 @@ export const messageRouter = router({
         await prisma.message.delete({
           where: {
             id: input.id,
+            accountId: ctx.user.id,
           },
         });
 
@@ -108,6 +110,7 @@ export const messageRouter = router({
       const message = await prisma.message.findUnique({
         where: {
           id: input.id,
+          accountId: ctx.user.id,
         },
         select: {
           conversationId: true,

--- a/server/routerTrpc/tag.ts
+++ b/server/routerTrpc/tag.ts
@@ -112,9 +112,9 @@ export const tagRouter = router({
       icon: z.string()
     }))
     .output(tagSchema)
-    .mutation(async function ({ input }) {
+    .mutation(async function ({ input, ctx }) {
       const { id, icon } = input
-      return await prisma.tag.update({ where: { id }, data: { icon } })
+      return await prisma.tag.update({ where: { id, accountId: ctx.user.id }, data: { icon } })
     }),
   deleteOnlyTag: authProcedure.use(demoAuthMiddleware)
     .meta({


### PR DESCRIPTION
This PR fixes a critical IDOR vulnerability where authenticated users could modify or delete resources they did not own. Linked to issue #1112.