### PR TITLE
fix(right-click-menu): handle embedding-delete error on note delete

### DIFF
--- a/app/src/components/BlinkoRightClickMenu/index.tsx
+++ b/app/src/components/BlinkoRightClickMenu/index.tsx
@@ -302,7 +302,7 @@ const handleTrash = () => {
 const handleDelete = async () => {
   const blinko = RootStore.Get(BlinkoStore)
   PromiseCall(api.notes.deleteMany.mutate({ ids: [blinko.curSelectedNote?.id!] }))
-  api.ai.embeddingDelete.mutate({ id: blinko.curSelectedNote?.id! })
+  PromiseCall(api.ai.embeddingDelete.mutate({ id: blinko.curSelectedNote?.id! }))
 }
 
 const handleRelatedNotes = async () => {


### PR DESCRIPTION
## Summary

`handleDelete` in `BlinkoRightClickMenu` fires `api.ai.embeddingDelete.mutate(...)` without an error shell. The matching `notes.deleteMany.mutate(...)` directly above it is wrapped in `PromiseCall(...)`, but the embedding mutate isn't — so when the call rejects (network failure, `Unauthorized`, `Forbidden`, framework error), the rejection becomes an unhandled promise rejection instead of a toast or session-expired signout.

This PR adds the missing `PromiseCall(...)` wrap to match the convention used everywhere else in this file. One line, no new imports.

## Why

When a user right-clicks → Delete on a note, two backend mutations run:

1. `api.notes.deleteMany.mutate(...)` — wrapped in `PromiseCall` ✓
2. `api.ai.embeddingDelete.mutate(...)` — **not wrapped** ✗

The wrap matters in three real cases:

- **Session expired between page load and delete.** `authProcedure` (`server/middleware/index.ts:25-32`) throws `TRPCError({ code: "UNAUTHORIZED" })` before the procedure body runs. `PromiseCall` → `PromiseState.call()` (`store/standard/PromiseState.ts:129-133`) translates `Unauthorized` into `eventBus.emit('user:signout')`. Without the wrap, the rejection is silently swallowed and the user keeps clicking with a dead session.
- **Network failure** (timeout, connection refused, offline). The wrap shows a toast with the upstream message; the unwrapped path fires an unhandled promise rejection that's invisible to the user.
- **Permission errors.** Same middleware can throw `FORBIDDEN`; the wrap toasts the message rather than swallowing it.

This is the same fix-shape you already apply on the immediately preceding line (L304) and at L299 in `handleTrash`. The asymmetry looks like a copy-paste oversight.

## Solution

One line: wrap `api.ai.embeddingDelete.mutate(...)` in `PromiseCall(...)`.

```diff
 const handleDelete = async () => {
   const blinko = RootStore.Get(BlinkoStore)
   PromiseCall(api.notes.deleteMany.mutate({ ids: [blinko.curSelectedNote?.id!] }))
-  api.ai.embeddingDelete.mutate({ id: blinko.curSelectedNote?.id! })
+  PromiseCall(api.ai.embeddingDelete.mutate({ id: blinko.curSelectedNote?.id! }))
 }
```

No new imports (`PromiseCall` is already imported at line 7).

## Scope note

Internal vector-store errors (e.g., transient libsql/pgvector issues) are already handled server-side: the procedure body in `server/routerTrpc/ai.ts:54-62` wraps `AiService.embeddingDelete` in try/catch and returns `{ ok: false, msg }` on failure — so those don't reject the client and aren't part of what this PR fixes. The wrap here is specifically about the auth/network/framework paths described above.

## Testing

Reproduced the auth scenario manually by clearing the auth token in localStorage and clicking Delete:

- **Before fix:** note delete request returns 401, gets toasted + signed out via `PromiseCall(notes.deleteMany.mutate)`. The subsequent `embeddingDelete` 401 is swallowed silently — no toast, no second sign-out signal (harmless because the first wins, but still inconsistent).
- **After fix:** both requests route through the same `PromiseCall` machinery; behavior is uniform.

Also ran `cd app && bun run build:web` — vite build (with `vite-plugin-checker` running TypeScript in band) completes cleanly, so the change is type-safe.

The frontend `app/` workspace has no test runner configured (server uses vitest under `server/__tests__/`); happy to follow up with a vitest setup for `app/` in a separate PR if you'd like that surface covered.

## Loom video

https://www.loom.com/share/39d4a10e7fb247ed83207e6b2eac44ab