### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/app/src/components/BlinkoSettings/AiSetting/AIIcon.tsx
+++ b/app/src/components/BlinkoSettings/AiSetting/AIIcon.tsx
@@ -45,6 +45,7 @@ const PROVIDER_ICONS: Record<string, React.ComponentType<any>> = {
   siliconflow: SiliconCloud.Color,
   voyageai: Voyage.Color,
   voyage: Voyage.Color,
+  litellm: OpenRouter,
   custom: OpenAI,
 };
 

--- a/app/src/components/BlinkoSettings/AiSetting/constants.tsx
+++ b/app/src/components/BlinkoSettings/AiSetting/constants.tsx
@@ -146,5 +146,15 @@ export const PROVIDER_TEMPLATES = [
     docs: 'https://platform.minimaxi.com/document/introduction',
     icon: 'minimax',
     description: 'MiniMax M2.7, M2.5 and other MiniMax models'
+  },
+  {
+    value: 'litellm',
+    label: 'LiteLLM',
+    defaultName: 'LiteLLM',
+    defaultBaseURL: 'http://localhost:4000/v1',
+    website: 'https://litellm.ai',
+    docs: 'https://docs.litellm.ai/docs',
+    icon: 'litellm',
+    description: 'AI gateway proxy - access 100+ LLM providers through a single endpoint'
   }
 ];

--- a/server/aiServer/providers/EmbeddingProvider.ts
+++ b/server/aiServer/providers/EmbeddingProvider.ts
@@ -49,6 +49,13 @@ export class EmbeddingProvider extends BaseProvider {
           headers: config.apiKey?.trim() ? { 'Authorization': `Bearer ${config.apiKey.trim()}`} : undefined
         }).textEmbeddingModel(config.modelKey);
 
+      case 'litellm':
+        return createOpenAI({
+          apiKey: config.apiKey,
+          baseURL: config.baseURL || 'http://localhost:4000/v1',
+          fetch: this.proxiedFetch
+        }).textEmbeddingModel(config.modelKey);
+
       case 'custom':
       default:
         // Default to OpenAI-compatible API

--- a/server/aiServer/providers/LLMProvider.ts
+++ b/server/aiServer/providers/LLMProvider.ts
@@ -83,6 +83,13 @@ export class LLMProvider extends BaseProvider {
           fetch: this.proxiedFetch
         }).languageModel(config.modelKey);
 
+      case 'litellm':
+        return createOpenAI({
+          apiKey: config.apiKey,
+          baseURL: config.baseURL || 'http://localhost:4000/v1',
+          fetch: this.proxiedFetch
+        }).languageModel(config.modelKey);
+
       case 'custom':
       default:
         return createOpenAI({

--- a/server/aiServer/providers/__tests__/litellm-provider.test.ts
+++ b/server/aiServer/providers/__tests__/litellm-provider.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+
+// Mock the proxy module before importing LLMProvider
+mock.module('@server/lib/proxy', () => ({
+  fetchWithProxy: async () => fetch
+}));
+
+// Mock @ai-sdk/openai
+const mockLanguageModel = { modelId: 'anthropic/claude-3-5-sonnet' };
+const mockEmbeddingModel = { modelId: 'text-embedding-3-small' };
+const mockCreateOpenAI = mock((config: any) => ({
+  languageModel: mock((modelKey: string) => mockLanguageModel),
+  textEmbeddingModel: mock((modelKey: string) => mockEmbeddingModel)
+}));
+
+mock.module('@ai-sdk/openai', () => ({
+  createOpenAI: mockCreateOpenAI
+}));
+
+// Mock other SDK modules to avoid import errors
+mock.module('@ai-sdk/anthropic', () => ({
+  createAnthropic: mock(() => ({ languageModel: mock(() => ({})) }))
+}));
+mock.module('@ai-sdk/google', () => ({
+  createGoogleGenerativeAI: mock(() => ({ languageModel: mock(() => ({})) }))
+}));
+mock.module('ollama-ai-provider', () => ({
+  createOllama: mock(() => ({ languageModel: mock(() => ({})), textEmbeddingModel: mock(() => ({})) }))
+}));
+mock.module('@ai-sdk/deepseek', () => ({
+  createDeepSeek: mock(() => ({ languageModel: mock(() => ({})) }))
+}));
+mock.module('@openrouter/ai-sdk-provider', () => ({
+  createOpenRouter: mock(() => ({ languageModel: mock(() => ({})) }))
+}));
+mock.module('@ai-sdk/xai', () => ({
+  createXai: mock(() => ({ languageModel: mock(() => ({})) }))
+}));
+mock.module('@ai-sdk/azure', () => ({
+  createAzure: mock(() => ({ languageModel: mock(() => ({})), textEmbeddingModel: mock(() => ({})) }))
+}));
+mock.module('voyage-ai-provider', () => ({
+  createVoyage: mock(() => ({ textEmbeddingModel: mock(() => ({})) }))
+}));
+
+describe('LiteLLM LLM Provider', () => {
+  beforeEach(() => {
+    mockCreateOpenAI.mockClear();
+  });
+
+  it('should handle litellm provider case', async () => {
+    const { LLMProvider } = await import('../LLMProvider');
+    const provider = new LLMProvider();
+
+    const result = await provider.getLanguageModel({
+      provider: 'litellm',
+      apiKey: 'sk-litellm-key',
+      baseURL: 'http://localhost:4000/v1',
+      modelKey: 'anthropic/claude-3-5-sonnet'
+    });
+
+    expect(result).toBeDefined();
+    expect(mockCreateOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'sk-litellm-key',
+        baseURL: 'http://localhost:4000/v1'
+      })
+    );
+  });
+
+  it('should use default LiteLLM proxy URL when not provided', async () => {
+    const { LLMProvider } = await import('../LLMProvider');
+    const provider = new LLMProvider();
+
+    await provider.getLanguageModel({
+      provider: 'litellm',
+      apiKey: 'sk-litellm-key',
+      modelKey: 'openai/gpt-4o-mini'
+    });
+
+    expect(mockCreateOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: 'http://localhost:4000/v1'
+      })
+    );
+  });
+
+  it('should allow custom proxy URL override', async () => {
+    const { LLMProvider } = await import('../LLMProvider');
+    const provider = new LLMProvider();
+
+    await provider.getLanguageModel({
+      provider: 'litellm',
+      apiKey: 'sk-litellm-key',
+      baseURL: 'https://my-proxy.example.com/v1',
+      modelKey: 'anthropic/claude-3-5-sonnet'
+    });
+
+    expect(mockCreateOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: 'https://my-proxy.example.com/v1'
+      })
+    );
+  });
+
+  it('should be case-insensitive for provider name', async () => {
+    const { LLMProvider } = await import('../LLMProvider');
+    const provider = new LLMProvider();
+
+    await provider.getLanguageModel({
+      provider: 'LiteLLM',
+      apiKey: 'sk-key',
+      modelKey: 'openai/gpt-4o'
+    });
+
+    expect(mockCreateOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: 'http://localhost:4000/v1'
+      })
+    );
+  });
+
+  it('should support various litellm model key formats', async () => {
+    const { LLMProvider } = await import('../LLMProvider');
+    const provider = new LLMProvider();
+    const models = [
+      'openai/gpt-4o',
+      'anthropic/claude-3-5-sonnet',
+      'azure/gpt-4',
+      'bedrock/anthropic.claude-3-sonnet',
+      'vertex_ai/gemini-pro'
+    ];
+
+    for (const modelKey of models) {
+      mockCreateOpenAI.mockClear();
+      await provider.getLanguageModel({
+        provider: 'litellm',
+        apiKey: 'sk-key',
+        modelKey
+      });
+      expect(mockCreateOpenAI).toHaveBeenCalled();
+    }
+  });
+
+  it('should pass proxiedFetch to createOpenAI', async () => {
+    const { LLMProvider } = await import('../LLMProvider');
+    const provider = new LLMProvider();
+
+    await provider.getLanguageModel({
+      provider: 'litellm',
+      apiKey: 'sk-key',
+      modelKey: 'openai/gpt-4o-mini'
+    });
+
+    expect(mockCreateOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fetch: expect.any(Function)
+      })
+    );
+  });
+});
+
+describe('LiteLLM Embedding Provider', () => {
+  beforeEach(() => {
+    mockCreateOpenAI.mockClear();
+  });
+
+  it('should handle litellm embedding provider', async () => {
+    const { EmbeddingProvider } = await import('../EmbeddingProvider');
+    const provider = new EmbeddingProvider();
+
+    const result = await provider.getEmbeddingModel({
+      provider: 'litellm',
+      apiKey: 'sk-litellm-key',
+      baseURL: 'http://localhost:4000/v1',
+      modelKey: 'text-embedding-3-small'
+    });
+
+    expect(result).toBeDefined();
+    expect(mockCreateOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'sk-litellm-key',
+        baseURL: 'http://localhost:4000/v1'
+      })
+    );
+  });
+
+  it('should use default proxy URL for embeddings', async () => {
+    const { EmbeddingProvider } = await import('../EmbeddingProvider');
+    const provider = new EmbeddingProvider();
+
+    await provider.getEmbeddingModel({
+      provider: 'litellm',
+      apiKey: 'sk-key',
+      modelKey: 'text-embedding-3-small'
+    });
+
+    expect(mockCreateOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: 'http://localhost:4000/v1'
+      })
+    );
+  });
+});


### PR DESCRIPTION


## Summary
- Adds [LiteLLM](https://github.com/BerriAI/litellm) as a first-class AI provider, enabling users to route AI requests through 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex AI, Groq, Ollama, etc.) via a single LiteLLM proxy.
- Follows the existing provider pattern exactly (modeled after MiniMax provider).

## Motivation
LiteLLM acts as a unified AI gateway. Instead of configuring individual provider connections, self-hosters can point blinko at a single LiteLLM proxy that handles provider routing, load balancing, cost tracking, and fallbacks across 100+ providers. This is useful for teams that already run a LiteLLM proxy for their infrastructure, or users who need providers not yet directly supported (e.g., AWS Bedrock, Vertex AI).

## Changes

- `server/aiServer/providers/LLMProvider.ts` - added `case 'litellm':` to the provider switch, uses `createOpenAI` with proxy URL (default `http://localhost:4000/v1`)
- `server/aiServer/providers/EmbeddingProvider.ts` - added `case 'litellm':` for embedding model support via the proxy
- `app/src/components/BlinkoSettings/AiSetting/constants.tsx` - added LiteLLM to `PROVIDER_TEMPLATES` with default config
- `app/src/components/BlinkoSettings/AiSetting/AIIcon.tsx` - added LiteLLM icon mapping
- `server/aiServer/providers/__tests__/litellm-provider.test.ts` - 8 unit tests for both LLM and Embedding providers

## Tests

**1. Unit tests (8/8 pass):**

    $ bun test server/aiServer/providers/__tests__/litellm-provider.test.ts

    8 pass
    0 fail
    14 expect() calls
    Ran 8 tests across 1 file. [46.00ms]

Tests cover:
- LiteLLM LLM provider routing with API key and base URL
- Default proxy URL (`http://localhost:4000/v1`) when not provided
- Custom proxy URL override
- Case-insensitive provider name (`LiteLLM` vs `litellm`)
- Multiple litellm model key formats (`openai/gpt-4o`, `anthropic/claude-3-5-sonnet`, `azure/gpt-4`, `bedrock/...`, `vertex_ai/...`)
- Proxied fetch passthrough
- LiteLLM embedding provider routing
- Default proxy URL for embeddings

**2. Full regression (17/17 pass):**

    $ bun test server/aiServer/providers/__tests__/

    17 pass
    0 fail
    Ran 17 tests across 3 files. [15.00ms]

**3. TypeScript type check clean:**

    $ npx tsc --noEmit
    (no errors)

**4. No new dependencies** - uses the existing `@ai-sdk/openai` package since LiteLLM proxy serves an OpenAI-compatible API.

## Risk / Compatibility
- Additive only. Existing providers completely untouched.
- No new dependencies added.
- Default proxy URL is `http://localhost:4000/v1` (standard LiteLLM proxy port).

## Example usage

In Blinko Settings > AI Settings, add a new provider:
1. Select "LiteLLM" from the provider list
2. Enter your LiteLLM proxy URL (e.g., `http://localhost:4000/v1`)
3. Enter your LiteLLM API key
4. Add models using LiteLLM model IDs (e.g., `anthropic/claude-3-5-sonnet`, `openai/gpt-4o`, `bedrock/anthropic.claude-3-sonnet`)

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## Summary
- Adds [LiteLLM](https://github.com/BerriAI/litellm) as a first-class AI provider, enabling users to route AI requests through 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex AI, Groq, Ollama, etc.) via a single LiteLLM proxy.
- Follows the existing provider pattern exactly (modeled after MiniMax provider).

## Motivation
LiteLLM acts as a unified AI gateway. Instead of configuring individual provider connections, self-hosters can point blinko at a single LiteLLM proxy that handles provider routing, load balancing, cost tracking, and fallbacks across 100+ providers. This is useful for teams that already run a LiteLLM proxy for their infrastructure, or users who need providers not yet directly supported (e.g., AWS Bedrock, Vertex AI).

## Changes

- `server/aiServer/providers/LLMProvider.ts` - added `case 'litellm':` to the provider switch, uses `createOpenAI` with proxy URL (default `http://localhost:4000/v1`)
- `server/aiServer/providers/EmbeddingProvider.ts` - added `case 'litellm':` for embedding model support via the proxy
- `app/src/components/BlinkoSettings/AiSetting/constants.tsx` - added LiteLLM to `PROVIDER_TEMPLATES` with default config
- `app/src/components/BlinkoSettings/AiSetting/AIIcon.tsx` - added LiteLLM icon mapping
- `server/aiServer/providers/__tests__/litellm-provider.test.ts` - 8 unit tests for both LLM and Embedding providers

## Tests

**1. Unit tests (8/8 pass):**

    $ bun test server/aiServer/providers/__tests__/litellm-provider.test.ts

    8 pass
    0 fail
    14 expect() calls
    Ran 8 tests across 1 file. [46.00ms]

Tests cover:
- LiteLLM LLM provider routing with API key and base URL
- Default proxy URL (`http://localhost:4000/v1`) when not provided
- Custom proxy URL override
- Case-insensitive provider name (`LiteLLM` vs `litellm`)
- Multiple litellm model key formats (`openai/gpt-4o`, `anthropic/claude-3-5-sonnet`, `azure/gpt-4`, `bedrock/...`, `vertex_ai/...`)
- Proxied fetch passthrough
- LiteLLM embedding provider routing
- Default proxy URL for embeddings

**2. Full regression (17/17 pass):**

    $ bun test server/aiServer/providers/__tests__/

    17 pass
    0 fail
    Ran 17 tests across 3 files. [15.00ms]

**3. TypeScript type check clean:**

    $ npx tsc --noEmit
    (no errors)

**4. No new dependencies** - uses the existing `@ai-sdk/openai` package since LiteLLM proxy serves an OpenAI-compatible API.

## Risk / Compatibility
- Additive only. Existing providers completely untouched.
- No new dependencies added.
- Default proxy URL is `http://localhost:4000/v1` (standard LiteLLM proxy port).

## Example usage

In Blinko Settings > AI Settings, add a new provider:
1. Select "LiteLLM" from the provider list
2. Enter your LiteLLM proxy URL (e.g., `http://localhost:4000/v1`)
3. Enter your LiteLLM API key
4. Add models using LiteLLM model IDs (e.g., `anthropic/claude-3-5-sonnet`, `openai/gpt-4o`, `bedrock/anthropic.claude-3-sonnet`)
