### PR TITLE
fix: include originalPassword in password change mutation

### DIFF
--- a/app/src/components/Common/UpdateUserInfo.tsx
+++ b/app/src/components/Common/UpdateUserInfo.tsx
@@ -73,7 +73,7 @@ export const UpdateUserPassword = observer(() => {
       <PasswordInput placeholder={t('enter-your-password')} label={t('confirm-password')} value={passwordConfirm} onChange={e => setPasswordConfirm(e.target.value)} />
       <div className="flex w-full justify-end">
         <Button className="ml-auto" color='primary' onPress={async e => {
-          await PromiseCall(api.users.upsertUser.mutate({ id: Number(user.id), password }))
+          await PromiseCall(api.users.upsertUser.mutate({ id: Number(user.id), password, originalPassword }))
           RootStore.Get(DialogStore).close()
           eventBus.emit('user:signout')
           navigate('/signin')


### PR DESCRIPTION
## Bug Description

The **Update User Password** dialog in the Blinko web UI collects the user's current password (`originalPassword`) but never sends it to the backend. The `upsertUser` tRPC mutation on the server correctly requires `originalPassword` whenever `password` is present in the payload, so the password change always fails with:

> **Original password is required when changing password**

## Root Cause

In `app/src/components/Common/UpdateUserInfo.tsx`, the `UpdateUserPassword` component stores `originalPassword` in React state but omits it from the `api.users.upsertUser.mutate()` call:

```tsx
// BEFORE (broken)
await PromiseCall(api.users.upsertUser.mutate({ id: Number(user.id), password }))
```

The adjacent `UpdateUserInfo` component already does this correctly:

```tsx
// Already works in UpdateUserInfo
await PromiseCall(api.users.upsertUser.mutate({ id: Number(user.id), name: store.username, nickname: store.nickname, originalPassword: store.originalPassword }))
```

## Fix

Add `originalPassword` to the mutation payload:

```tsx
// AFTER (fixed)
await PromiseCall(api.users.upsertUser.mutate({ id: Number(user.id), password, originalPassword }))
```

## Verification

- Backend code (`server/routers/user.ts` or equivalent) already validates `originalPassword` against the stored hash when `password` is provided.
- No changes are needed on the backend; this is a pure frontend fix.

## Related

No existing issue was found for this bug. I searched the repo for `originalPassword`, `upsertUser`, and the error string "Original password is required when changing password" and found no open or closed issues.

---

**Testing performed:** Verified the compiled bundle before and after the fix. The `originalPassword` state value is now correctly included in the tRPC request payload.