### PR TITLE
Follow up fix based on #1131

### DIFF
--- a/server/routerExpress/auth/config.ts
+++ b/server/routerExpress/auth/config.ts
@@ -15,12 +15,32 @@ import { cache } from '@shared/lib/cache';
 // Cache TTL in milliseconds (20 seconds)
 const CACHE_TTL = 20 * 1000;
 
+let oauthStrategiesInitialized = false;
+let oauthInitializationPromise: Promise<void> | null = null;
+
 export const configureSession = async (app: any) => {
   await initJwtStrategy();
   initLocalStrategy();
-  await initOAuthStrategies();
-  
+
   app.use(passport.initialize());
+};
+
+export const ensureOAuthStrategies = async () => {
+  if (oauthStrategiesInitialized) {
+    return;
+  }
+
+  if (!oauthInitializationPromise) {
+    oauthInitializationPromise = initOAuthStrategies()
+      .then(() => {
+        oauthStrategiesInitialized = true;
+      })
+      .finally(() => {
+        oauthInitializationPromise = null;
+      });
+  }
+
+  await oauthInitializationPromise;
 };
 
 async function handleOAuthCallback(accessToken: string, refreshToken: string, profile: any, done: any) {
@@ -435,9 +455,12 @@ export const reinitializeOAuthStrategies = async () => {
         // Strategy might not exist, continue
       }
     }
+
+    oauthStrategiesInitialized = false;
+    oauthInitializationPromise = null;
     
     // Re-initialize OAuth strategies
-    await initOAuthStrategies();
+    await ensureOAuthStrategies();
     return { success: true, message: 'OAuth strategies reinitialized' };
   } catch (error) {
     console.error('Failed to reinitialize OAuth strategies:', error);
@@ -445,4 +468,4 @@ export const reinitializeOAuthStrategies = async () => {
   }
 };
 
-export default passport; 
+export default passport;

--- a/server/routerExpress/auth/config.ts
+++ b/server/routerExpress/auth/config.ts
@@ -16,7 +16,17 @@ import { cache } from '@shared/lib/cache';
 const CACHE_TTL = 20 * 1000;
 
 let oauthStrategiesInitialized = false;
-let oauthInitializationPromise: Promise<void> | null = null;
+let oauthInitializationPromise: Promise<string[]> | null = null;
+const registeredOAuthProviderIds = new Set<string>();
+
+const hasOAuthStrategy = (providerId: string) => {
+  return Boolean((passport as any)._strategy(providerId));
+};
+
+const useOAuthStrategy = (providerId: string, strategy: any) => {
+  passport.use(providerId, strategy);
+  registeredOAuthProviderIds.add(providerId);
+};
 
 export const configureSession = async (app: any) => {
   await initJwtStrategy();
@@ -25,22 +35,33 @@ export const configureSession = async (app: any) => {
   app.use(passport.initialize());
 };
 
-export const ensureOAuthStrategies = async () => {
-  if (oauthStrategiesInitialized) {
+export const ensureOAuthStrategies = async (providerId?: string) => {
+  if (providerId && hasOAuthStrategy(providerId)) {
+    return;
+  }
+
+  if (!providerId && oauthStrategiesInitialized) {
     return;
   }
 
   if (!oauthInitializationPromise) {
     oauthInitializationPromise = initOAuthStrategies()
-      .then(() => {
-        oauthStrategiesInitialized = true;
+      .then((failedProviders) => {
+        oauthStrategiesInitialized = failedProviders.length === 0;
+        return failedProviders;
       })
       .finally(() => {
         oauthInitializationPromise = null;
       });
   }
 
-  await oauthInitializationPromise;
+  const failedProviders = await oauthInitializationPromise;
+
+  if (providerId && !hasOAuthStrategy(providerId)) {
+    oauthStrategiesInitialized = false;
+    const reason = failedProviders.includes(providerId) ? 'failed to initialize' : 'is not configured';
+    throw new Error(`OAuth strategy "${providerId}" ${reason}`);
+  }
 };
 
 async function handleOAuthCallback(accessToken: string, refreshToken: string, profile: any, done: any) {
@@ -241,11 +262,12 @@ const initOAuthStrategies = async () => {
   try {
     const config = await getGlobalConfig({ useAdmin: true });
     const providers = config.oauth2Providers || [];
+    const failedProviders: string[] = [];
     for (const provider of providers) {
       const callbackURL = `/api/auth/callback/${provider.id}`;
       switch (provider.id) {
         case 'github':
-          passport.use(new GitHubStrategy({
+          useOAuthStrategy(provider.id, new GitHubStrategy({
             clientID: provider.clientId,
             clientSecret: provider.clientSecret,
             callbackURL: callbackURL
@@ -253,7 +275,7 @@ const initOAuthStrategies = async () => {
           break;
 
         case 'google':
-          passport.use(new GoogleStrategy({
+          useOAuthStrategy(provider.id, new GoogleStrategy({
             clientID: provider.clientId,
             clientSecret: provider.clientSecret,
             callbackURL: callbackURL
@@ -261,7 +283,7 @@ const initOAuthStrategies = async () => {
           break;
 
         case 'facebook':
-          passport.use(new FacebookStrategy({
+          useOAuthStrategy(provider.id, new FacebookStrategy({
             clientID: provider.clientId,
             clientSecret: provider.clientSecret,
             callbackURL: callbackURL,
@@ -270,7 +292,7 @@ const initOAuthStrategies = async () => {
           break;
 
         case 'twitter':
-          passport.use(new TwitterStrategy({
+          useOAuthStrategy(provider.id, new TwitterStrategy({
             consumerKey: provider.clientId,
             consumerSecret: provider.clientSecret,
             callbackURL: callbackURL,
@@ -279,7 +301,7 @@ const initOAuthStrategies = async () => {
           break;
 
         case 'discord':
-          passport.use(new DiscordStrategy({
+          useOAuthStrategy(provider.id, new DiscordStrategy({
             clientID: provider.clientId,
             clientSecret: provider.clientSecret,
             callbackURL: callbackURL,
@@ -291,7 +313,7 @@ const initOAuthStrategies = async () => {
         case 'spotify':
           try {
             const SpotifyStrategy = require('passport-spotify').Strategy;
-            passport.use(new SpotifyStrategy({
+            useOAuthStrategy(provider.id, new SpotifyStrategy({
               clientID: provider.clientId,
               clientSecret: provider.clientSecret,
               callbackURL: callbackURL,
@@ -299,13 +321,14 @@ const initOAuthStrategies = async () => {
             }, handleOAuthCallback));
           } catch (error) {
             console.error('Spotify strategy requires passport-spotify package');
+            failedProviders.push(provider.id);
           }
           break;
 
         case 'apple':
           try {
             const AppleStrategy = require('passport-apple');
-            passport.use(new AppleStrategy({
+            useOAuthStrategy(provider.id, new AppleStrategy({
               clientID: provider.clientId,
               clientSecret: provider.clientSecret,
               callbackURL: callbackURL,
@@ -313,13 +336,14 @@ const initOAuthStrategies = async () => {
             }, handleOAuthCallback));
           } catch (error) {
             console.error('Apple strategy requires passport-apple package');
+            failedProviders.push(provider.id);
           }
           break;
 
         case 'slack':
           try {
             const SlackStrategy = require('passport-slack').Strategy;
-            passport.use(new SlackStrategy({
+            useOAuthStrategy(provider.id, new SlackStrategy({
               clientID: provider.clientId,
               clientSecret: provider.clientSecret,
               callbackURL: callbackURL,
@@ -327,13 +351,14 @@ const initOAuthStrategies = async () => {
             }, handleOAuthCallback));
           } catch (error) {
             console.error('Slack strategy requires passport-slack package');
+            failedProviders.push(provider.id);
           }
           break;
 
         case 'twitch':
           try {
             const TwitchStrategy = require('passport-twitch-new').Strategy;
-            passport.use(new TwitchStrategy({
+            useOAuthStrategy(provider.id, new TwitchStrategy({
               clientID: provider.clientId,
               clientSecret: provider.clientSecret,
               callbackURL: callbackURL,
@@ -341,13 +366,14 @@ const initOAuthStrategies = async () => {
             }, handleOAuthCallback));
           } catch (error) {
             console.error('Twitch strategy requires passport-twitch-new package');
+            failedProviders.push(provider.id);
           }
           break;
 
         case 'line':
           try {
             const LineStrategy = require('passport-line').Strategy;
-            passport.use(new LineStrategy({
+            useOAuthStrategy(provider.id, new LineStrategy({
               channelID: provider.clientId,
               channelSecret: provider.clientSecret,
               callbackURL: callbackURL,
@@ -355,6 +381,7 @@ const initOAuthStrategies = async () => {
             }, handleOAuthCallback));
           } catch (error) {
             console.error('Line strategy requires passport-line package');
+            failedProviders.push(provider.id);
           }
           break;
 
@@ -393,7 +420,7 @@ const initOAuthStrategies = async () => {
                 };
               }
 
-              passport.use(provider.id, new OAuth2Strategy(oauthConfig,
+              useOAuthStrategy(provider.id, new OAuth2Strategy(oauthConfig,
                 async (req, accessToken, refreshToken, profile, done) => {
                   try {
                     if (provider.wellKnown) {
@@ -431,13 +458,16 @@ const initOAuthStrategies = async () => {
               ));
             } catch (error) {
               console.error(`Failed to initialize custom OAuth provider: ${provider.id}`, error);
+              failedProviders.push(provider.id);
             }
           }
           break;
       }
     }
+    return failedProviders;
   } catch (error) {
     console.error('Failed to initialize OAuth strategies:', error);
+    throw error;
   }
 };
 
@@ -448,20 +478,20 @@ export const reinitializeOAuthStrategies = async () => {
     const providers = config.oauth2Providers || [];
     
     // Unregister existing OAuth strategies
-    for (const provider of providers) {
+    const providerIds = new Set([...providers.map(provider => provider.id), ...registeredOAuthProviderIds]);
+    for (const providerId of providerIds) {
       try {
-        passport.unuse(provider.id);
+        passport.unuse(providerId);
       } catch (error) {
         // Strategy might not exist, continue
       }
     }
+    registeredOAuthProviderIds.clear();
 
     oauthStrategiesInitialized = false;
     oauthInitializationPromise = null;
     
-    // Re-initialize OAuth strategies
-    await ensureOAuthStrategies();
-    return { success: true, message: 'OAuth strategies reinitialized' };
+    return { success: true, message: 'OAuth strategies reset' };
   } catch (error) {
     console.error('Failed to reinitialize OAuth strategies:', error);
     return { success: false, error: error.message };

--- a/server/routerExpress/auth/index.ts
+++ b/server/routerExpress/auth/index.ts
@@ -1,5 +1,6 @@
 import express from 'express';
-import passport from './config';
+import passport, { ensureOAuthStrategiesInitialized } from './config';
+
 import { prisma } from '../../prisma';
 import { authenticator } from 'otplib';
 import { getGlobalConfig } from '../../routerTrpc/config';
@@ -33,12 +34,14 @@ const logOAuthRequest = (provider: string) => (req: any, res: any, next: any) =>
   next();
 };
 
-router.get('/github', logOAuthRequest('GitHub'), (req, res, next) => {
+router.get('/github', logOAuthRequest('GitHub'), async (req, res, next) => {
+  await ensureOAuthStrategiesInitialized();
   console.log('GitHub authentication route accessed');
   passport.authenticate('github', { scope: ['user:email'] })(req, res, next);
 });
 
-router.get('/callback/:providerId', (req, res, next) => {
+router.get('/callback/:providerId', async (req, res, next) => {
+  await ensureOAuthStrategiesInitialized();
   const providerId = req.params.providerId;
   console.log(`${providerId} callback route accessed`);
   passport.authenticate(providerId, (err, user, info) => {
@@ -46,7 +49,8 @@ router.get('/callback/:providerId', (req, res, next) => {
   })(req, res, next);
 });
 
-router.get('/google', logOAuthRequest('Google'), (req, res, next) => {
+router.get('/google', logOAuthRequest('Google'), async (req, res, next) => {
+  await ensureOAuthStrategiesInitialized();
   console.log('Google authentication route accessed');
   passport.authenticate('google', { scope: ['profile', 'email'] })(req, res, next);
 });

--- a/server/routerExpress/auth/index.ts
+++ b/server/routerExpress/auth/index.ts
@@ -58,8 +58,7 @@ router.get('/google', logOAuthRequest('Google'), async (req, res, next) => {
 router.get('/facebook', logOAuthRequest('Facebook'), async (req, res, next) => {
   await ensureOAuthStrategies();
   console.log('facebook authentication route accessed');
-   passport.authenticate('facebook', { scope: ['email'] })(req, res, next);
-
+  passport.authenticate('facebook', { scope: ['email'] })(req, res, next);
 });
 
 router.get('/twitter', logOAuthRequest('Twitter'), async (req, res, next) => {
@@ -70,7 +69,7 @@ router.get('/twitter', logOAuthRequest('Twitter'), async (req, res, next) => {
 
 router.get('/discord', logOAuthRequest('Discord'), async (req, res, next) => {
   await ensureOAuthStrategies();
-  console.log('twitter authentication route accessed');
+  console.log('discord authentication route accessed');
   passport.authenticate('discord', { scope: ['identify', 'email'] })(req, res, next);
 });
 
@@ -218,7 +217,7 @@ router.get('/profile', async (req: any, res) => {
 });
 
 router.get('/:providerId', logOAuthRequest('Custom'), async (req, res, next) => {
-    await ensureOAuthStrategies();
+  await ensureOAuthStrategies();
   const providerId = req.params.providerId;
   console.log(`Custom OAuth provider ${providerId} authentication route accessed`);
   

--- a/server/routerExpress/auth/index.ts
+++ b/server/routerExpress/auth/index.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import passport, { ensureOAuthStrategiesInitialized } from './config';
+import passport, { ensureOAuthStrategies } from './config';
 
 import { prisma } from '../../prisma';
 import { authenticator } from 'otplib';
@@ -35,13 +35,13 @@ const logOAuthRequest = (provider: string) => (req: any, res: any, next: any) =>
 };
 
 router.get('/github', logOAuthRequest('GitHub'), async (req, res, next) => {
-  await ensureOAuthStrategiesInitialized();
+  await ensureOAuthStrategies();
   console.log('GitHub authentication route accessed');
   passport.authenticate('github', { scope: ['user:email'] })(req, res, next);
 });
 
 router.get('/callback/:providerId', async (req, res, next) => {
-  await ensureOAuthStrategiesInitialized();
+  await ensureOAuthStrategies();
   const providerId = req.params.providerId;
   console.log(`${providerId} callback route accessed`);
   passport.authenticate(providerId, (err, user, info) => {
@@ -50,16 +50,29 @@ router.get('/callback/:providerId', async (req, res, next) => {
 });
 
 router.get('/google', logOAuthRequest('Google'), async (req, res, next) => {
-  await ensureOAuthStrategiesInitialized();
+  await ensureOAuthStrategies();
   console.log('Google authentication route accessed');
   passport.authenticate('google', { scope: ['profile', 'email'] })(req, res, next);
 });
 
-router.get('/facebook', logOAuthRequest('Facebook'), passport.authenticate('facebook', { scope: ['email'] }));
+router.get('/facebook', logOAuthRequest('Facebook'), async (req, res, next) => {
+  await ensureOAuthStrategies();
+  console.log('facebook authentication route accessed');
+   passport.authenticate('facebook', { scope: ['email'] })(req, res, next);
 
-router.get('/twitter', logOAuthRequest('Twitter'), passport.authenticate('twitter'));
+});
 
-router.get('/discord', logOAuthRequest('Discord'), passport.authenticate('discord', { scope: ['identify', 'email'] }));
+router.get('/twitter', logOAuthRequest('Twitter'), async (req, res, next) => {
+  await ensureOAuthStrategies();
+  console.log('twitter authentication route accessed');
+  passport.authenticate('twitter')(req, res, next);
+});
+
+router.get('/discord', logOAuthRequest('Discord'), async (req, res, next) => {
+  await ensureOAuthStrategies();
+  console.log('twitter authentication route accessed');
+  passport.authenticate('discord', { scope: ['identify', 'email'] })(req, res, next);
+});
 
 
 router.post('/login', (req, res, next) => {
@@ -205,7 +218,7 @@ router.get('/profile', async (req: any, res) => {
 });
 
 router.get('/:providerId', logOAuthRequest('Custom'), async (req, res, next) => {
-    await ensureOAuthStrategiesInitialized();
+    await ensureOAuthStrategies();
   const providerId = req.params.providerId;
   console.log(`Custom OAuth provider ${providerId} authentication route accessed`);
   

--- a/server/routerExpress/auth/index.ts
+++ b/server/routerExpress/auth/index.ts
@@ -204,7 +204,8 @@ router.get('/profile', async (req: any, res) => {
   }
 });
 
-router.get('/:providerId', logOAuthRequest('Custom'), (req, res, next) => {
+router.get('/:providerId', logOAuthRequest('Custom'), async (req, res, next) => {
+    await ensureOAuthStrategiesInitialized();
   const providerId = req.params.providerId;
   console.log(`Custom OAuth provider ${providerId} authentication route accessed`);
   

--- a/server/routerExpress/auth/index.ts
+++ b/server/routerExpress/auth/index.ts
@@ -35,14 +35,14 @@ const logOAuthRequest = (provider: string) => (req: any, res: any, next: any) =>
 };
 
 router.get('/github', logOAuthRequest('GitHub'), async (req, res, next) => {
-  await ensureOAuthStrategies();
+  await ensureOAuthStrategies('github');
   console.log('GitHub authentication route accessed');
   passport.authenticate('github', { scope: ['user:email'] })(req, res, next);
 });
 
 router.get('/callback/:providerId', async (req, res, next) => {
-  await ensureOAuthStrategies();
   const providerId = req.params.providerId;
+  await ensureOAuthStrategies(providerId);
   console.log(`${providerId} callback route accessed`);
   passport.authenticate(providerId, (err, user, info) => {
     handleOAuthCallback(req, res, err, user, info);
@@ -50,25 +50,25 @@ router.get('/callback/:providerId', async (req, res, next) => {
 });
 
 router.get('/google', logOAuthRequest('Google'), async (req, res, next) => {
-  await ensureOAuthStrategies();
+  await ensureOAuthStrategies('google');
   console.log('Google authentication route accessed');
   passport.authenticate('google', { scope: ['profile', 'email'] })(req, res, next);
 });
 
 router.get('/facebook', logOAuthRequest('Facebook'), async (req, res, next) => {
-  await ensureOAuthStrategies();
+  await ensureOAuthStrategies('facebook');
   console.log('facebook authentication route accessed');
   passport.authenticate('facebook', { scope: ['email'] })(req, res, next);
 });
 
 router.get('/twitter', logOAuthRequest('Twitter'), async (req, res, next) => {
-  await ensureOAuthStrategies();
+  await ensureOAuthStrategies('twitter');
   console.log('twitter authentication route accessed');
   passport.authenticate('twitter')(req, res, next);
 });
 
 router.get('/discord', logOAuthRequest('Discord'), async (req, res, next) => {
-  await ensureOAuthStrategies();
+  await ensureOAuthStrategies('discord');
   console.log('discord authentication route accessed');
   passport.authenticate('discord', { scope: ['identify', 'email'] })(req, res, next);
 });
@@ -217,8 +217,8 @@ router.get('/profile', async (req: any, res) => {
 });
 
 router.get('/:providerId', logOAuthRequest('Custom'), async (req, res, next) => {
-  await ensureOAuthStrategies();
   const providerId = req.params.providerId;
+  await ensureOAuthStrategies(providerId);
   console.log(`Custom OAuth provider ${providerId} authentication route accessed`);
   
   const predefinedProviders = ['github', 'google', 'facebook', 'twitter', 'discord'];


### PR DESCRIPTION
This keeps the lazy OAuth initialization approach from #1131, but fixes the retry behavior when the first provider initialization attempt fails.