### PR TITLE
feat(ai): upgrade MiniMax models to M3

### DIFF
--- a/app/src/components/BlinkoSettings/AiSetting/constants.tsx
+++ b/app/src/components/BlinkoSettings/AiSetting/constants.tsx
@@ -145,6 +145,6 @@ export const PROVIDER_TEMPLATES = [
     website: 'https://www.minimaxi.com',
     docs: 'https://platform.minimaxi.com/document/introduction',
     icon: 'minimax',
-    description: 'MiniMax M2.7, M2.5 and other MiniMax models'
+    description: 'MiniMax M3, M2.7 and other MiniMax models'
   }
 ];

--- a/server/aiServer/providers/__tests__/minimax-integration.test.ts
+++ b/server/aiServer/providers/__tests__/minimax-integration.test.ts
@@ -23,7 +23,7 @@ describe('MiniMax API Integration', () => {
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({
-        model: 'MiniMax-M2.5-highspeed',
+        model: 'MiniMax-M3',
         messages: [{ role: 'user', content: 'Reply with "ok"' }],
         max_tokens: 5,
         temperature: 0.1
@@ -36,7 +36,7 @@ describe('MiniMax API Integration', () => {
     expect(data.choices[0].message.content).toBeTruthy();
   }, TIMEOUT);
 
-  it('should complete a chat request with MiniMax-M2.5', async () => {
+  it('should complete a chat request with MiniMax-M3', async () => {
     if (skip) return;
 
     const response = await fetch(`${MINIMAX_BASE_URL}/chat/completions`, {
@@ -46,7 +46,7 @@ describe('MiniMax API Integration', () => {
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({
-        model: 'MiniMax-M2.5',
+        model: 'MiniMax-M3',
         messages: [{ role: 'user', content: 'Say "hello" and nothing else.' }],
         max_tokens: 10,
         temperature: 0.1
@@ -70,7 +70,7 @@ describe('MiniMax API Integration', () => {
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({
-        model: 'MiniMax-M2.5',
+        model: 'MiniMax-M3',
         messages: [{ role: 'user', content: 'Hi' }],
         max_tokens: 5,
         temperature: 0.1,

--- a/server/aiServer/providers/__tests__/minimax-provider.test.ts
+++ b/server/aiServer/providers/__tests__/minimax-provider.test.ts
@@ -6,7 +6,7 @@ mock.module('@server/lib/proxy', () => ({
 }));
 
 // Mock @ai-sdk/openai
-const mockLanguageModel = { modelId: 'MiniMax-M2.5' };
+const mockLanguageModel = { modelId: 'MiniMax-M3' };
 const mockCreateOpenAI = mock((config: any) => ({
   languageModel: mock((modelKey: string) => mockLanguageModel)
 }));
@@ -50,7 +50,7 @@ describe('MiniMax LLM Provider', () => {
     const result = await provider.getLanguageModel({
       provider: 'minimax',
       apiKey: 'test-api-key',
-      modelKey: 'MiniMax-M2.5'
+      modelKey: 'MiniMax-M3'
     });
 
     expect(result).toBeDefined();
@@ -87,7 +87,7 @@ describe('MiniMax LLM Provider', () => {
       provider: 'minimax',
       apiKey: 'test-key',
       baseURL: 'https://custom.minimax.io/v1',
-      modelKey: 'MiniMax-M2.5'
+      modelKey: 'MiniMax-M3'
     });
 
     expect(mockCreateOpenAI).toHaveBeenCalledWith(
@@ -104,7 +104,7 @@ describe('MiniMax LLM Provider', () => {
     await provider.getLanguageModel({
       provider: 'MiniMax',
       apiKey: 'test-key',
-      modelKey: 'MiniMax-M2.5'
+      modelKey: 'MiniMax-M3'
     });
 
     expect(mockCreateOpenAI).toHaveBeenCalledWith(
@@ -117,7 +117,7 @@ describe('MiniMax LLM Provider', () => {
   it('should support all MiniMax model keys', async () => {
     const { LLMProvider } = await import('../LLMProvider');
     const provider = new LLMProvider();
-    const models = ['MiniMax-M2.7', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'];
+    const models = ['MiniMax-M3', 'MiniMax-M2.7'];
 
     for (const modelKey of models) {
       mockCreateOpenAI.mockClear();
@@ -137,7 +137,7 @@ describe('MiniMax LLM Provider', () => {
     await provider.getLanguageModel({
       provider: 'minimax',
       apiKey: 'test-key',
-      modelKey: 'MiniMax-M2.5'
+      modelKey: 'MiniMax-M3'
     });
 
     expect(mockCreateOpenAI).toHaveBeenCalledWith(

--- a/server/routerTrpc/ai.ts
+++ b/server/routerTrpc/ai.ts
@@ -693,9 +693,8 @@ export const aiRouter = router({
           case 'minimax': {
             // Static list - MiniMax models with known capabilities
             modelList = [
-              { id: 'MiniMax-M2.7', name: 'MiniMax M2.7', capabilities: inferModelCapabilities('MiniMax-M2.7') },
-              { id: 'MiniMax-M2.5', name: 'MiniMax M2.5', capabilities: inferModelCapabilities('MiniMax-M2.5') },
-              { id: 'MiniMax-M2.5-highspeed', name: 'MiniMax M2.5 Highspeed', capabilities: inferModelCapabilities('MiniMax-M2.5-highspeed') }
+              { id: 'MiniMax-M3', name: 'MiniMax M3', capabilities: inferModelCapabilities('MiniMax-M3') },
+              { id: 'MiniMax-M2.7', name: 'MiniMax M2.7', capabilities: inferModelCapabilities('MiniMax-M2.7') }
             ];
             break;
           }

--- a/shared/lib/__tests__/minimax-model-templates.test.ts
+++ b/shared/lib/__tests__/minimax-model-templates.test.ts
@@ -7,7 +7,15 @@ describe('MiniMax Model Templates', () => {
   );
 
   it('should include MiniMax models in DEFAULT_MODEL_TEMPLATES', () => {
-    expect(minimaxModels.length).toBeGreaterThanOrEqual(3);
+    expect(minimaxModels.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('should have MiniMax-M3 model', () => {
+    const model = DEFAULT_MODEL_TEMPLATES.find(t => t.modelKey === 'MiniMax-M3');
+    expect(model).toBeDefined();
+    expect(model!.title).toBe('MiniMax M3');
+    expect(model!.capabilities.inference).toBe(true);
+    expect(model!.capabilities.tools).toBe(true);
   });
 
   it('should have MiniMax-M2.7 model', () => {
@@ -18,24 +26,24 @@ describe('MiniMax Model Templates', () => {
     expect(model!.capabilities.tools).toBe(true);
   });
 
-  it('should have MiniMax-M2.5 model', () => {
-    const model = DEFAULT_MODEL_TEMPLATES.find(t => t.modelKey === 'MiniMax-M2.5');
-    expect(model).toBeDefined();
-    expect(model!.title).toBe('MiniMax M2.5');
-    expect(model!.capabilities.inference).toBe(true);
-    expect(model!.capabilities.tools).toBe(true);
+  it('should list MiniMax-M3 before MiniMax-M2.7', () => {
+    const keys = minimaxModels.map(m => m.modelKey);
+    const indexM3 = keys.indexOf('MiniMax-M3');
+    const indexM27 = keys.indexOf('MiniMax-M2.7');
+    expect(indexM3).toBeGreaterThanOrEqual(0);
+    expect(indexM27).toBeGreaterThanOrEqual(0);
+    expect(indexM3).toBeLessThan(indexM27);
   });
 
-  it('should have MiniMax-M2.5-highspeed model', () => {
-    const model = DEFAULT_MODEL_TEMPLATES.find(t => t.modelKey === 'MiniMax-M2.5-highspeed');
-    expect(model).toBeDefined();
-    expect(model!.title).toBe('MiniMax M2.5 Highspeed');
-    expect(model!.capabilities.inference).toBe(true);
-    expect(model!.capabilities.tools).toBe(true);
+  it('should not include deprecated MiniMax-M2.5 models', () => {
+    const m25 = DEFAULT_MODEL_TEMPLATES.find(t => t.modelKey === 'MiniMax-M2.5');
+    const m25hs = DEFAULT_MODEL_TEMPLATES.find(t => t.modelKey === 'MiniMax-M2.5-highspeed');
+    expect(m25).toBeUndefined();
+    expect(m25hs).toBeUndefined();
   });
 
   it('should infer MiniMax model capabilities correctly', () => {
-    const caps = inferModelCapabilities('MiniMax-M2.5');
+    const caps = inferModelCapabilities('MiniMax-M3');
     expect(caps.inference).toBe(true);
     expect(caps.tools).toBe(true);
     expect(caps.embedding).toBe(false);
@@ -48,8 +56,8 @@ describe('MiniMax Model Templates', () => {
     expect(caps.tools).toBe(true);
   });
 
-  it('should infer capabilities for MiniMax-M2.5-highspeed', () => {
-    const caps = inferModelCapabilities('MiniMax-M2.5-highspeed');
+  it('should infer capabilities for MiniMax-M3', () => {
+    const caps = inferModelCapabilities('MiniMax-M3');
     expect(caps.inference).toBe(true);
     expect(caps.tools).toBe(true);
   });

--- a/shared/lib/modelTemplates.ts
+++ b/shared/lib/modelTemplates.ts
@@ -86,9 +86,8 @@ export const DEFAULT_MODEL_TEMPLATES: ModelTemplate[] = [
   { modelKey: 'qwen-vl-max', title: 'Qwen VL Max', capabilities: { inference: true, image: true } },
 
   // MiniMax Models
+  { modelKey: 'MiniMax-M3', title: 'MiniMax M3', capabilities: { inference: true, tools: true } },
   { modelKey: 'MiniMax-M2.7', title: 'MiniMax M2.7', capabilities: { inference: true, tools: true } },
-  { modelKey: 'MiniMax-M2.5', title: 'MiniMax M2.5', capabilities: { inference: true, tools: true } },
-  { modelKey: 'MiniMax-M2.5-highspeed', title: 'MiniMax M2.5 Highspeed', capabilities: { inference: true, tools: true } },
 
   // DeepSeek Models
   { modelKey: 'deepseek-chat', title: 'DeepSeek Chat', capabilities: { inference: true, tools: true } },


### PR DESCRIPTION
## Summary

Upgrades the bundled MiniMax model list to M3 and prunes the older M2.5 SKUs while keeping M2.7 as a backward-compatible option.

## Changes

- `shared/lib/modelTemplates.ts`: add `MiniMax-M3` at the head of the MiniMax section, keep `MiniMax-M2.7`, drop `MiniMax-M2.5` and `MiniMax-M2.5-highspeed`.
- `server/routerTrpc/ai.ts`: update the static `minimax` model list returned by `getProviderModels` to expose `M3` first followed by `M2.7`.
- `app/src/components/BlinkoSettings/AiSetting/constants.tsx`: refresh the provider description text from "M2.7, M2.5" to "M3, M2.7".
- Tests:
  - `shared/lib/__tests__/minimax-model-templates.test.ts`: assert M3 exists, M3 is listed before M2.7, and deprecated M2.5 entries are absent.
  - `server/aiServer/providers/__tests__/minimax-provider.test.ts`: switch mock + parametric tests to M3/M2.7.
  - `server/aiServer/providers/__tests__/minimax-integration.test.ts`: use `MiniMax-M3` for live API checks.

## Notes

- The provider config (`https://api.minimax.io/v1`, OpenAI-compatible SDK, env var `MINIMAX_API_KEY`) is unchanged.
- No DB schema or migration impact; UI defaults follow the existing list-order behavior, so M3 becomes the implicit default model for new MiniMax setups.

## Test plan

- [x] `bun test shared/lib/__tests__/minimax-model-templates.test.ts` — 10/10 pass
- [x] `bun test server/aiServer/providers/__tests__/minimax-provider.test.ts` — 6/6 pass
- [x] `bun test server/aiServer/providers/__tests__/minimax-integration.test.ts` — 3/3 pass (skipped without `MINIMAX_API_KEY`)