### PR TITLE
feat: add heic/heif image format support

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -59,6 +59,7 @@
     "emoji-picker-react": "^4.12.2",
     "filesize": "^8.0.7",
     "framer-motion": "^11.0.0",
+    "heic-convert": "^2.1.0",
     "i18next": "^25.6.0",
     "i18next-browser-languagedetector": "^8.0.4",
     "i18next-http-backend": "^3.0.2",

--- a/app/src/components/BlinkoResource/ResourceItem.tsx
+++ b/app/src/components/BlinkoResource/ResourceItem.tsx
@@ -133,7 +133,9 @@ const ResourceCard = observer(({ item, isSelected, onSelect, isDragging, isDragg
     item.name?.endsWith('.bmp') ||
     item.name?.endsWith('.tiff') ||
     item.name?.endsWith('.ico') ||
-    item.name?.endsWith('.webp');
+    item.name?.endsWith('.webp') ||
+    item.name?.endsWith('.heic') ||
+    item.name?.endsWith('.heif');
 
   const fileNameAndExt = useMemo(() => {
     const fileName = toJS(item.name);

--- a/app/src/components/Common/Editor/editorStore.tsx
+++ b/app/src/components/Common/Editor/editorStore.tsx
@@ -1,6 +1,7 @@
 import { RootStore } from '@/store';
 import { PromiseState } from '@/store/standard/PromiseState';
 import { helper } from '@/lib/helper';
+import { convertHeicToJpeg } from '@/lib/heicConvert';
 import { FileType, OnSendContentType } from './type';
 import { BlinkoStore } from '@/store/blinkoStore';
 import { api } from '@/lib/trpc';
@@ -203,6 +204,10 @@ export class EditorStore {
     const uploadFileType = {}
 
     const _acceptedFiles = await Promise.all(acceptedFiles.map(async file => {
+      // Convert HEIC/HEIF to JPEG in the browser so previews render and the
+      // server never has to deal with HEIC decoding.
+      file = await convertHeicToJpeg(file)
+
       const extension = helper.getFileExtension(file.name)
       const previewType = helper.getFileType(file.type, file.name)
       const isUserVoiceRecording = file.isUserVoiceRecording || false

--- a/app/src/components/Common/UploadFile/index.tsx
+++ b/app/src/components/Common/UploadFile/index.tsx
@@ -10,6 +10,7 @@ import { BlinkoStore } from "@/store/blinkoStore";
 import { observer } from "mobx-react-lite";
 import { getBlinkoEndpoint } from "@/lib/blinkoEndpoint";
 import axiosInstance from "@/lib/axios";
+import { convertHeicToJpeg } from "@/lib/heicConvert";
 type IProps = {
   onUpload?: ({ filePath, fileName }) => void
   children?: React.ReactNode
@@ -28,12 +29,12 @@ export const UploadFileWrapper = observer(({ onUpload, children, acceptImage = f
     multiple: false,
     noClick: true,
     accept: acceptImage ? {
-      'image/*': ['.jpeg', '.jpg', '.png', '.gif', '.webp']
+      'image/*': ['.jpeg', '.jpg', '.png', '.gif', '.webp', '.heic', '.heif']
     } : undefined,
     onDrop: async acceptedFiles => {
       setIsLoading(true)
       try {
-        const file = acceptedFiles[0]!
+        const file = await convertHeicToJpeg(acceptedFiles[0]!)
         const formData = new FormData();
         formData.append('file', file)
 

--- a/app/src/lib/heicConvert.ts
+++ b/app/src/lib/heicConvert.ts
@@ -1,0 +1,30 @@
+import heicConvert from 'heic-convert/browser';
+
+const HEIC_MIME = new Set(['image/heic', 'image/heif']);
+const HEIC_EXT = /\.(heic|heif)$/i;
+
+export function isHeicFile(file: File): boolean {
+  return HEIC_MIME.has(file.type) || HEIC_EXT.test(file.name);
+}
+
+/**
+ * Convert a HEIC/HEIF file to a JPEG File in the browser.
+ * Returns the original file if it is not HEIC.
+ */
+export async function convertHeicToJpeg(file: File, quality = 0.85): Promise<File> {
+  if (!isHeicFile(file)) return file;
+
+  const buffer = await file.arrayBuffer();
+  const jpeg = await heicConvert({
+    buffer: new Uint8Array(buffer),
+    format: 'JPEG',
+    quality,
+  });
+
+  const baseName = file.name.replace(HEIC_EXT, '');
+  return new File(
+    [new Blob([jpeg as ArrayBufferView], { type: 'image/jpeg' })],
+    `${baseName}.jpg`,
+    { type: 'image/jpeg' },
+  );
+}

--- a/app/src/lib/helper.ts
+++ b/app/src/lib/helper.ts
@@ -134,7 +134,7 @@ export const helper = {
       if (mimeType?.startsWith('image')) return 'image'
     }
 
-    if ('jpeg/jpg/png/bmp/tiff/tif/webp/svg'.includes(extension?.toLowerCase() ?? null)) {
+    if ('jpeg/jpg/png/bmp/tiff/tif/webp/svg/heic/heif'.includes(extension?.toLowerCase() ?? null)) {
       return 'image'
     }
     if ('mp4/webm/ogg/mov/wmv'.includes(extension?.toLowerCase() ?? null)) {

--- a/bun.lock
+++ b/bun.lock
@@ -1,10 +1,12 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "blinko-monorepo",
       "dependencies": {
         "dotenv": "^16.5.0",
+        "heic-convert": "^2.1.0",
         "lru-cache": "^11.1.0",
         "react-i18next": "^15.4.1",
         "react-simple-pull-to-refresh": "^1.3.3",
@@ -65,6 +67,7 @@
         "emoji-picker-react": "^4.12.2",
         "filesize": "^8.0.7",
         "framer-motion": "^11.0.0",
+        "heic-convert": "^2.1.0",
         "i18next": "^25.6.0",
         "i18next-browser-languagedetector": "^8.0.4",
         "i18next-http-backend": "^3.0.2",
@@ -2313,7 +2316,7 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
-    "bun-types": ["bun-types@1.3.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-qyschsA03Qz+gou+apt6HNl6HnI+sJJLL4wLDke4iugsE6584CMupOtTY1n+2YC9nGVrEKUlTs99jjRLKgWnjQ=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
 
@@ -3027,6 +3030,10 @@
 
     "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
 
+    "heic-convert": ["heic-convert@2.1.0", "", { "dependencies": { "heic-decode": "^2.0.0", "jpeg-js": "^0.4.4", "pngjs": "^6.0.0" } }, "sha512-1qDuRvEHifTVAj3pFIgkqGgJIr0M3X7cxEPjEp0oG4mo8GFjq99DpCo8Eg3kg17Cy0MTjxpFdoBHOatj7ZVKtg=="],
+
+    "heic-decode": ["heic-decode@2.1.0", "", { "dependencies": { "libheif-js": "^1.19.8" } }, "sha512-0fB3O3WMk38+PScbHLVp66jcNhsZ/ErtQ6u2lMYu/YxXgbBtl+oKOhGQHa4RpvE68k8IzbWkABzHnyAIjR758A=="],
+
     "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
 
     "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
@@ -3243,6 +3250,8 @@
 
     "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
 
+    "jpeg-js": ["jpeg-js@0.4.4", "", {}, "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="],
+
     "js-base64": ["js-base64@3.7.8", "", {}, "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow=="],
 
     "js-cookie": ["js-cookie@3.0.5", "", {}, "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="],
@@ -3314,6 +3323,8 @@
     "leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "libheif-js": ["libheif-js@1.19.8", "", {}, "sha512-vQJWusIxO7wavpON1dusciL8Go9jsIQ+EUrckauFYAiSTjcmLAsuJh3SszLpvkwPci3JcL41ek2n+LUZGFpPIQ=="],
 
     "libsql": ["libsql@0.5.22", "", { "dependencies": { "@neon-rs/load": "^0.0.4", "detect-libc": "2.0.2" }, "optionalDependencies": { "@libsql/darwin-arm64": "0.5.22", "@libsql/darwin-x64": "0.5.22", "@libsql/linux-arm-gnueabihf": "0.5.22", "@libsql/linux-arm-musleabihf": "0.5.22", "@libsql/linux-arm64-gnu": "0.5.22", "@libsql/linux-arm64-musl": "0.5.22", "@libsql/linux-x64-gnu": "0.5.22", "@libsql/linux-x64-musl": "0.5.22", "@libsql/win32-x64-msvc": "0.5.22" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "arm", "x64", "arm64", ] }, "sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA=="],
 
@@ -3885,6 +3896,8 @@
 
     "playwright-core": ["playwright-core@1.56.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ=="],
 
+    "pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
+
     "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
 
     "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
@@ -4063,7 +4076,7 @@
 
     "rc-checkbox": ["rc-checkbox@3.5.0", "", { "dependencies": { "@babel/runtime": "^7.10.1", "classnames": "^2.3.2", "rc-util": "^5.25.2" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-aOAQc3E98HteIIsSqm6Xk2FPKIER6+5vyEFMZfo73TqM+VVAIqOkHoPjgKLqSNtVLWScoaM7vY2ZrGEheI79yg=="],
 
-    "rc-collapse": ["rc-collapse@3.9.0", "", { "dependencies": { "@babel/runtime": "^7.10.1", "classnames": "2.x", "rc-motion": "^2.3.4", "rc-util": "^5.27.0" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-swDdz4QZ4dFTo4RAUMLL50qP0EY62N2kvmk2We5xYdRwcRn8WcYtuetCJpwpaCbUfUt5+huLpVxhvmnK+PHrkA=="],
+    "rc-collapse": ["rc-collapse@4.0.0", "", { "dependencies": { "@babel/runtime": "^7.10.1", "classnames": "2.x", "rc-motion": "^2.3.4", "rc-util": "^5.27.0" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-SwoOByE39/3oIokDs/BnkqI+ltwirZbP8HZdq1/3SkPSBi7xDdvWHTp7cpNI9ullozkR6mwTWQi6/E/9huQVrA=="],
 
     "rc-dialog": ["rc-dialog@9.6.0", "", { "dependencies": { "@babel/runtime": "^7.10.1", "@rc-component/portal": "^1.0.0-8", "classnames": "^2.2.6", "rc-motion": "^2.3.0", "rc-util": "^5.21.0" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-ApoVi9Z8PaCQg6FsUzS8yvBEQy0ZL2PkuvAgrmohPkN3okps5WZ5WQWPc1RNuiOKaAYv8B97ACdsFU5LizzCqg=="],
 
@@ -5021,8 +5034,6 @@
 
     "@lobehub/ui/lucide-react": ["lucide-react@0.543.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-fpVfuOQO0V3HBaOA1stIiP/A2fPCXHIleRZL16Mx3HmjTYwNSbimhnFBygs2CAfU1geexMX5ItUcWBGUaqw5CA=="],
 
-    "@lobehub/ui/rc-collapse": ["rc-collapse@4.0.0", "", { "dependencies": { "@babel/runtime": "^7.10.1", "classnames": "2.x", "rc-motion": "^2.3.4", "rc-util": "^5.27.0" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-SwoOByE39/3oIokDs/BnkqI+ltwirZbP8HZdq1/3SkPSBi7xDdvWHTp7cpNI9ullozkR6mwTWQi6/E/9huQVrA=="],
-
     "@lobehub/ui/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "@mastra/core/ai": ["ai@4.3.19", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "@ai-sdk/react": "1.2.12", "@ai-sdk/ui-utils": "1.2.11", "@opentelemetry/api": "1.9.0", "jsondiffpatch": "0.6.0" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "zod": "^3.23.8" }, "optionalPeers": ["react"] }, "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q=="],
@@ -5196,6 +5207,8 @@
     "ai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.7", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-o3BS5/t8KnBL3ubP8k3w77AByOypLm+pkIL/DCw0qKkhDbvhCy+L3hRTGPikpdb8WHcylAeKsjgwOxhj4cqTUA=="],
 
     "ajv-formats/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "antd/rc-collapse": ["rc-collapse@3.9.0", "", { "dependencies": { "@babel/runtime": "^7.10.1", "classnames": "2.x", "rc-motion": "^2.3.4", "rc-util": "^5.27.0" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-swDdz4QZ4dFTo4RAUMLL50qP0EY62N2kvmk2We5xYdRwcRn8WcYtuetCJpwpaCbUfUt5+huLpVxhvmnK+PHrkA=="],
 
     "antd/scroll-into-view-if-needed": ["scroll-into-view-if-needed@3.1.0", "", { "dependencies": { "compute-scroll-into-view": "^3.0.2" } }, "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ=="],
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "dotenv": "^16.5.0",
+    "heic-convert": "^2.1.0",
     "lru-cache": "^11.1.0",
     "react-i18next": "^15.4.1",
     "react-simple-pull-to-refresh": "^1.3.3",


### PR DESCRIPTION
## Summary

Add HEIC/HEIF image format support with automatic client-side conversion to JPEG.

## What does this MR do?

This MR enables users to upload and view HEIC/HEIF images (widely used by modern smartphones and cameras) in Blinko. Since most browsers do not natively render HEIC/HEIF, selected files are **automatically converted to JPEG in the browser** using `heic-convert` (WASM, based on libheif). The resulting JPEG is used both for the in-app preview and for the upload, so the server stays unchanged.

## Changes

### Frontend — automatic HEIC → JPEG conversion

- **`app/src/lib/heicConvert.ts`** (new) — `convertHeicToJpeg(file)` utility: detects HEIC/HEIF by MIME type or file extension, decodes the image via `heic-convert/browser` and returns a new `File` containing the JPEG at 85% quality. Non-HEIC files pass through unchanged.
- **`app/src/components/Common/Editor/editorStore.tsx`** — `uploadFiles()` invokes `convertHeicToJpeg()` first, so the preview's object URL and the upload payload both use the converted JPEG. No changes to preview/upload branching.
- **`app/src/components/Common/UploadFile/index.tsx`** — direct upload flow also calls `convertHeicToJpeg()` before submitting the multipart request.
- **`app/package.json`** — adds `heic-convert@2.1.0` (pulls in `heic-decode`, `libheif-js` WASM bundle).

### Frontend — recognize HEIC/HEIF as images

- **`app/src/lib/helper.ts`** — added `heic`/`heif` to the file-type-to-category mapping.
- **`app/src/components/Common/UploadFile/index.tsx`** — added `.heic`/`.heif` to the upload acceptor list so the OS file picker shows HEIC files.
- **`app/src/components/BlinkoResource/ResourceItem.tsx`** — added `.heic`/`.heif` to the in-browser image preview check (defensive: covers any pre-existing HEIC files in storage).

## Why?

HEIC/HEIF is the default capture format on many modern smartphones (iOS, Android) and cameras, offering better compression than JPEG. However, browser support for native rendering is still limited. Doing the conversion in the browser gives the user a working preview the moment they pick a HEIC file, and ships a single JPEG to the server — no server-side decoder, no extra Docker dependencies, no race-prone stream rewriting.
