### PR TITLE
fix：修复blinko hub不能查看全文并支持hub url可自定义配置|| fix: Fix blinko hub being unable to view the full text and supporting hub url customizable configuration

### DIFF
--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -839,5 +839,8 @@
   "custom-title": "Custom Title",
   "custom-title-tip": "Used for browser tab and sign-in title. Leave empty to use the default title.",
   "custom-title-placeholder": "Enter a title (1-50 chars)",
-  "login-with": "Login With {{title}}"
+  "login-with": "Login With {{title}}",
+  "custom-hub-url": "Custom Hub URL",
+  "custom-hub-url-tip": "Configure custom Blinko Hub index.json URL. Leave empty to use default official Hub.",
+  "custom-hub-url-placeholder": "e.g., https://cdn.jsdelivr.net/gh/Inverstar/blinko-hub@main/index.json"
 }

--- a/app/public/locales/zh/translation.json
+++ b/app/public/locales/zh/translation.json
@@ -856,5 +856,8 @@
   "custom-title": "自定义标题",
   "custom-title-tip": "用于浏览器标签页和登录页标题，留空将使用默认标题。",
   "custom-title-placeholder": "请输入标题（1-50个字符）",
-  "login-with": "登录 {{title}}"
+  "login-with": "登录 {{title}}",
+  "custom-hub-url": "自定义 Hub 数据源 URL",
+  "custom-hub-url-tip": "配置自定义 Blinko Hub 的 index.json 地址，留空将默认使用官方 Hub。",
+  "custom-hub-url-placeholder": "例如：https://cdn.jsdelivr.net/gh/Inverstar/blinko-hub@main/index.json"
 }

--- a/app/src/components/BlinkoCard/FullscreenEditor.tsx
+++ b/app/src/components/BlinkoCard/FullscreenEditor.tsx
@@ -14,14 +14,17 @@ import { MarkdownRender } from "@/components/Common/MarkdownRender";
 import { FilesAttachmentRender } from "../Common/AttachmentRender";
 import { ReferencesContent } from "./referencesContent";
 import { useTranslation } from "react-i18next";
+import { CardFooter } from "./cardFooter";
+import { SimpleCommentList } from "./commentButton";
 
 interface FullscreenEditorProps {
   blinkoItem: BlinkoItem;
   isOpen: boolean;
   onClose: () => void;
+  isShareMode?: boolean;
 }
 
-export const FullscreenEditor = observer(({ blinkoItem, isOpen, onClose }: FullscreenEditorProps) => {
+export const FullscreenEditor = observer(({ blinkoItem, isOpen, onClose, isShareMode = false }: FullscreenEditorProps) => {
   const isPc = useMediaQuery('(min-width: 768px)');
   const blinko = RootStore.Get(BlinkoStore);
   const { t } = useTranslation();
@@ -38,6 +41,7 @@ export const FullscreenEditor = observer(({ blinkoItem, isOpen, onClose }: Fulls
 
   // Switch to edit mode
   const handleSwitchToEdit = () => {
+    if (isShareMode) return;
     setEditorMode('edit');
   };
 
@@ -74,20 +78,20 @@ export const FullscreenEditor = observer(({ blinkoItem, isOpen, onClose }: Fulls
   // Set curSelectedNote when opening editor
   useEffect(() => {
     if (isOpen) {
-      // Load fresh note data from server
-      if (blinkoItem.id) {
+      if (!isShareMode && blinkoItem.id) {
+        // Load fresh note data from server for local notes
         blinko.noteDetail.call({ id: blinkoItem.id }).then(() => {
           if (blinko.noteDetail.value) {
             blinko.curSelectedNote = _.cloneDeep(blinko.noteDetail.value);
           }
         });
       } else {
-        // Fallback to prop data if no id
+        // Fallback to prop data if shared or remote note
         blinko.curSelectedNote = _.cloneDeep(blinkoItem);
         blinko.noteDetail.value = _.cloneDeep(blinkoItem);
       }
     }
-  }, [isOpen, blinkoItem.id]);
+  }, [isOpen, blinkoItem.id, isShareMode]);
 
   // Handle ESC key to close editor
   useEffect(() => {
@@ -205,30 +209,32 @@ export const FullscreenEditor = observer(({ blinkoItem, isOpen, onClose }: Fulls
                 <Icon icon="tabler:arrow-left" width={20} height={20} />
               </Button>
               <div className="flex-1 flex justify-end ml-2 gap-2">
-                {editorMode === 'preview' ? (
-                  <Tooltip content={t('edit')}>
-                    <Button
-                      isIconOnly
-                      variant="light"
-                      size="sm"
-                      onPress={handleSwitchToEdit}
-                      className="text-foreground hover:bg-default-100"
-                    >
-                      <Icon icon="tabler:edit" width={20} height={20} />
-                    </Button>
-                  </Tooltip>
-                ) : (
-                  <Tooltip content={t('preview')}>
-                    <Button
-                      isIconOnly
-                      variant="light"
-                      size="sm"
-                      onPress={handleSwitchToPreview}
-                      className="text-foreground hover:bg-default-100"
-                    >
-                      <Icon icon="tabler:eye" width={20} height={20} />
-                    </Button>
-                  </Tooltip>
+                {!isShareMode && (
+                  editorMode === 'preview' ? (
+                    <Tooltip content={t('edit')}>
+                      <Button
+                        isIconOnly
+                        variant="light"
+                        size="sm"
+                        onPress={handleSwitchToEdit}
+                        className="text-foreground hover:bg-default-100"
+                      >
+                        <Icon icon="tabler:edit" width={20} height={20} />
+                      </Button>
+                    </Tooltip>
+                  ) : (
+                    <Tooltip content={t('preview')}>
+                      <Button
+                        isIconOnly
+                        variant="light"
+                        size="sm"
+                        onPress={handleSwitchToPreview}
+                        className="text-foreground hover:bg-default-100"
+                      >
+                        <Icon icon="tabler:eye" width={20} height={20} />
+                      </Button>
+                    </Tooltip>
+                  )
                 )}
                 {editorMode === 'edit' && (
                   <div id={`editor-top-toolbar-${blinkoItem.id}`} className="flex justify-end"></div>
@@ -242,19 +248,30 @@ export const FullscreenEditor = observer(({ blinkoItem, isOpen, onClose }: Fulls
             <div
               className="flex-1 overflow-y-auto min-h-0 py-4"
               style={{ height: isPc ? 'calc(100vh - 100px)' : 'calc(100vh - 80px)' }}
-              onDoubleClick={handleSwitchToEdit}
+              onDoubleClick={isShareMode ? undefined : handleSwitchToEdit}
             >
               <MarkdownRender
-                content={blinko.noteDetail.value?.content ?? blinkoItem.content}
+                content={isShareMode ? blinkoItem.content : (blinko.noteDetail.value?.content ?? blinkoItem.content)}
                 onChange={(newContent) => {
+                  if (isShareMode) return;
                   blinkoItem.content = newContent;
                   blinko.upsertNote.call({ id: blinkoItem.id, content: newContent, refresh: false });
                 }}
+                isShareMode={isShareMode}
                 largeSpacing={true}
               />
-              <ReferencesContent blinkoItem={blinko.noteDetail.value ?? blinkoItem} className="my-4" />
+              <ReferencesContent blinkoItem={isShareMode ? blinkoItem : (blinko.noteDetail.value ?? blinkoItem)} className="my-4" />
               <div className={blinkoItem.attachments?.length != 0 ? 'my-2' : ''}>
-                <FilesAttachmentRender files={blinko.noteDetail.value?.attachments ?? blinkoItem.attachments ?? []} preview />
+                <FilesAttachmentRender files={(isShareMode ? blinkoItem.attachments : blinko.noteDetail.value?.attachments) ?? blinkoItem.attachments ?? []} preview />
+              </div>
+
+              <div className="mt-6 pt-4 border-t border-border">
+                <CardFooter blinkoItem={blinkoItem} blinko={blinko} isShareMode={isShareMode} />
+                {!blinko.config.value?.isHideCommentInCard && (
+                  <div className="mt-2">
+                    <SimpleCommentList blinkoItem={blinkoItem} />
+                  </div>
+                )}
               </div>
             </div>
           ) : (
@@ -286,30 +303,32 @@ export const FullscreenEditor = observer(({ blinkoItem, isOpen, onClose }: Fulls
                 <Icon icon="tabler:arrow-left" width={20} height={20} />
               </Button>
               <div className="flex-1 flex justify-end ml-2 gap-2">
-                {editorMode === 'preview' ? (
-                  <Tooltip content={t('edit')}>
-                    <Button
-                      isIconOnly
-                      variant="light"
-                      size="sm"
-                      onPress={handleSwitchToEdit}
-                      className="text-foreground hover:bg-default-100"
-                    >
-                      <Icon icon="tabler:edit" width={20} height={20} />
-                    </Button>
-                  </Tooltip>
-                ) : (
-                  <Tooltip content={t('preview')}>
-                    <Button
-                      isIconOnly
-                      variant="light"
-                      size="sm"
-                      onPress={handleSwitchToPreview}
-                      className="text-foreground hover:bg-default-100"
-                    >
-                      <Icon icon="tabler:eye" width={20} height={20} />
-                    </Button>
-                  </Tooltip>
+                {!isShareMode && (
+                  editorMode === 'preview' ? (
+                    <Tooltip content={t('edit')}>
+                      <Button
+                        isIconOnly
+                        variant="light"
+                        size="sm"
+                        onPress={handleSwitchToEdit}
+                        className="text-foreground hover:bg-default-100"
+                      >
+                        <Icon icon="tabler:edit" width={20} height={20} />
+                      </Button>
+                    </Tooltip>
+                  ) : (
+                    <Tooltip content={t('preview')}>
+                      <Button
+                        isIconOnly
+                        variant="light"
+                        size="sm"
+                        onPress={handleSwitchToPreview}
+                        className="text-foreground hover:bg-default-100"
+                      >
+                        <Icon icon="tabler:eye" width={20} height={20} />
+                      </Button>
+                    </Tooltip>
+                  )
                 )}
                 {editorMode === 'edit' && (
                   <div id={`editor-top-toolbar-${blinkoItem.id}`} className="flex justify-end"></div>

--- a/app/src/components/BlinkoCard/index.tsx
+++ b/app/src/components/BlinkoCard/index.tsx
@@ -67,7 +67,7 @@ export const BlinkoCard = observer(({ blinkoItem, account, isShareMode = false, 
   const handleClick = () => {
     if (blinko.isMultiSelectMode) {
       blinko.onMultiSelectNote(blinkoItem.id!);
-    } else if (blinkoItem.isBlog && !isShareMode) {
+    } else if (blinkoItem.isBlog) {
       setIsFullscreenEditorOpen(true);
       blinko.fullscreenEditorNoteId = blinkoItem.id!;
     }
@@ -105,6 +105,7 @@ export const BlinkoCard = observer(({ blinkoItem, account, isShareMode = false, 
         blinkoItem={blinkoItem}
         isOpen={isFullscreenEditorOpen}
         onClose={() => setIsFullscreenEditorOpen(false)}
+        isShareMode={isShareMode}
       />
 
       {(() => {

--- a/app/src/components/BlinkoSettings/PerferSetting.tsx
+++ b/app/src/components/BlinkoSettings/PerferSetting.tsx
@@ -27,6 +27,7 @@ export const PerferSetting = observer(() => {
   const [customBackgroundUrl, setCustomBackgroundUrl] = useState(blinko.config.value?.customBackgroundUrl || '');
   const [signinFooterText, setSigninFooterText] = useState(blinko.config.value?.signinFooterText || '');
   const [customTitle, setCustomTitle] = useState(blinko.config.value?.customTitle || '');
+  const [customHubUrl, setCustomHubUrl] = useState(blinko.config.value?.customHubUrl || '');
   const user = RootStore.Get(UserStore)
 
   useEffect(() => {
@@ -36,7 +37,8 @@ export const PerferSetting = observer(() => {
     setCustomBackgroundUrl(blinko.config.value?.customBackgroundUrl || '');
     setSigninFooterText(blinko.config.value?.signinFooterText || '');
     setCustomTitle(blinko.config.value?.customTitle || '');
-  }, [blinko.config.value?.textFoldLength, blinko.config.value?.maxHomePageWidth, blinko.config.value?.customBackgroundUrl, blinko.config.value?.signinFooterText, blinko.config.value?.customTitle]);
+    setCustomHubUrl(blinko.config.value?.customHubUrl || '');
+  }, [blinko.config.value?.textFoldLength, blinko.config.value?.maxHomePageWidth, blinko.config.value?.customBackgroundUrl, blinko.config.value?.signinFooterText, blinko.config.value?.customTitle, blinko.config.value?.customHubUrl]);
 
 
   return <CollapsibleCard
@@ -431,6 +433,34 @@ export const PerferSetting = observer(() => {
               await PromiseCall(api.config.update.mutate({
                 key: 'customTitle',
                 value: titleValue
+              }));
+              blinko.config.call();
+            }} />} />
+      )
+    }
+
+    {
+      user.isSuperAdmin && (
+        <Item
+          type={isPc ? 'row' : 'col'}
+          leftContent={<div className="flex flex-col">
+            <div>{t('custom-hub-url')}</div>
+            <div className="text-xs text-default-400">{t('custom-hub-url-tip')}</div>
+          </div>}
+          rightContent={<Input
+            className="w-full md:w-[400px]"
+            placeholder={t('custom-hub-url-placeholder')}
+            type="text"
+            value={customHubUrl}
+            onChange={e => {
+              setCustomHubUrl(e.target.value)
+            }}
+            onBlur={async () => {
+              const urlValue = customHubUrl.trim();
+              setCustomHubUrl(urlValue);
+              await PromiseCall(api.config.update.mutate({
+                key: 'customHubUrl',
+                value: urlValue
               }));
               blinko.config.call();
             }} />} />

--- a/server/routerTrpc/public.ts
+++ b/server/routerTrpc/public.ts
@@ -410,16 +410,20 @@ export const publicRouter = router({
         }),
       ),
     )
-    .query(async function ({ input }) {
+    .query(async function ({ input, ctx }) {
       if (input?.refresh) {
         refreshTicker++;
       }
+      const globalConfig = await getGlobalConfig({ ctx, useAdmin: true });
+      const hubUrl = globalConfig.customHubUrl && globalConfig.customHubUrl.trim() !== ''
+        ? globalConfig.customHubUrl.trim()
+        : 'https://raw.githubusercontent.com/blinko-space/blinko-hub/refs/heads/main/index.json';
+
       return await cache.wrap(
-        `hub-site-list-${refreshTicker}`,
+        `hub-site-list-${refreshTicker}-${hubUrl}`,
         async () => {
           try {
-            //raw.gitmirror.com
-            const response = await getWithProxy('https://raw.githubusercontent.com/blinko-space/blinko-hub/refs/heads/main/index.json', {
+            const response = await getWithProxy(hubUrl, {
               config: {
                 headers: {
                   Accept: 'application/vnd.github.v3.raw',

--- a/shared/lib/types.ts
+++ b/shared/lib/types.ts
@@ -104,6 +104,7 @@ export const ZConfigKey = z.union([
   z.literal('signinFooterEnabled'),
   z.literal('signinFooterText'),
   z.literal('customTitle'),
+  z.literal('customHubUrl'),
   ZUserPerferConfigKey,
   z.any()
 ]);
@@ -193,7 +194,8 @@ export const ZConfigSchema = z.object({
   fontStyle: z.string().optional(),
   signinFooterEnabled: z.boolean().optional(),
   signinFooterText: z.string().optional(),
-  customTitle: z.string().optional()
+  customTitle: z.string().optional(),
+  customHubUrl: z.string().optional()
 });
 
 export type GlobalConfig = z.infer<typeof ZConfigSchema>;


### PR DESCRIPTION
1.支持全屏展开阅读 BlinkoCard/index.tsx：
- 移除了 handleClick 中对 !isShareMode 的过度限制，在 Hub 模式或浏览关注博主文章时点击卡片，均能成功调起全屏阅读模式（FullscreenEditor）。

2.只读保护与防错 FullscreenEditor.tsx：
- 接收 isShareMode 标记，当查看共享/外部博主文章时，不会向本地数据库请求不存在的 noteDetail，直接显示文章内容。
- 自动隐藏顶栏及移动端底栏的“编辑”图标，并屏蔽双击进入编辑模式，防止产生无权限操作与报错。

3.完整保留与增强评论体验：
- 在全屏阅读模式底部集成了 CardFooter 以及 SimpleCommentList 评论列表与评论按钮，用户在全屏沉浸阅读博主文章时可以随时查看与发表评论。

4.支持页面自定义blinko hub url，默认情况下保持使用 Blinko 官方 Hub 地址，同时提供前端偏好设置输入框，允许超级管理员配置第三方或自定义 Fork 的 Hub

---

所作变更
app/src/components/BlinkoCard

index.tsx
移除了 handleClick 中的 !isShareMode 检查，允许 Hub / 分享模式下的博客文章触发全屏阅读器（FullscreenEditor）。
向 <FullscreenEditor> 传递了 isShareMode={isShareMode} 属性。
FullscreenEditor.tsx
在 FullscreenEditorProps 中添加了 isShareMode?: boolean 选填属性。
修改了笔记详情加载逻辑：在 isShareMode 模式下，直接使用传入的 blinkoItem 内容，而不再发起本地数据库查询。
当 isShareMode 为 true 时，在 PC 端顶部标题栏和移动端底部工具栏中隐藏“编辑”按钮。
在分享模式下禁用了双击触发编辑模式的功能。
当 isShareMode 为 true 时，阻止 MarkdownRender 中的 onChange 触发 upsertNote（更新笔记）调用。
在 FullscreenEditor 底部集成了 CardFooter 与 SimpleCommentList（评论列表），方便读者在全屏阅读界面中直接查看与发表评论。

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
1. Support full-screen expanded reading of BlinkoCard/index.tsx:
- Removed excessive restrictions on !isShareMode in handleClick. Clicking on the card in Hub mode or while browsing articles of bloggers can successfully activate the full-screen reading mode (FullscreenEditor).

2. Read-only protection and error prevention FullscreenEditor.tsx:
- Receive the isShareMode tag. When viewing shared/external blogger articles, non-existent noteDetail will not be requested from the local database and the article content will be displayed directly.
- Automatically hide the "Edit" icon in the top bar and bottom bar on mobile devices, and block double-clicking to enter edit mode to prevent unauthorized operations and errors.

3. Completely retain and enhance the comment experience:
- CardFooter and SimpleCommentList comment lists and comment buttons are integrated at the bottom of the full-screen reading mode. Users can view and post comments at any time while reading blogger articles in full-screen immersion.

4. Support page customization of blinko hub url, keep using Blinko official Hub address by default, and provide front-end preference input box, allowing super administrator to configure third-party or custom fork Hub

---

Changes Made

app/src/components/BlinkoCard

index.tsx
Removed !isShareMode check in handleClick, allowing blog posts in Hub / share mode to trigger FullscreenEditor.
Passed isShareMode={isShareMode} to <FullscreenEditor>.

FullscreenEditor.tsx

Added isShareMode?: boolean to FullscreenEditorProps.
Modified note detail loading: for isShareMode, use blinkoItem content directly instead of making local DB queries.
Hidden "Edit" buttons in both PC top header and Mobile bottom toolbar when isShareMode is true.
Disabled onDoubleClick edit mode triggering in share mode.
Prevented onChange in MarkdownRender from calling upsertNote when isShareMode is true.
Integrated CardFooter and SimpleCommentList at the bottom of FullscreenEditor so readers can view and post comments directly in full screen view.
