### PR TITLE
fix: split view / raw markdown editor can't scroll in fullscreen (#1088)

### DIFF
--- a/app/src/styles/vditor.css
+++ b/app/src/styles/vditor.css
@@ -113,6 +113,20 @@
   overflow-x: hidden;
 }
 
+/*
+ * Split view (sv) and raw markdown modes render a single
+ * <pre class="vditor-sv vditor-reset"> that is both the container and the
+ * editable surface, so the ".vditor-sv .vditor-reset" descendant rule above
+ * never matches it and it is left with "overflow: hidden" from the group
+ * above, making it impossible to scroll (issue #1088). Let this combined
+ * element scroll itself instead of clipping.
+ */
+.vditor.fullscreen-editor .vditor-sv.vditor-reset {
+  display: block;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
 /* Long text mode - increased spacing */
 .editor-long-text .vditor-reset {
   padding-top: 12px;


### PR DESCRIPTION
Fixes #1088.

In fullscreen editing the split-view and raw-markdown panes can't be scrolled, while IR and WYSIWYG work fine. The reason is that sv/raw render as a single `<pre class="vditor-sv vditor-reset">` where the container and the editable surface are the same element, so the existing rule

```css
.vditor.fullscreen-editor .vditor-sv .vditor-reset { overflow-y: auto; }
```

never matches it (it's a descendant selector, but here `.vditor-reset` sits on the same element as `.vditor-sv`). The element is left with `overflow: hidden` from the group above, so it clips instead of scrolling. IR/WYSIWYG nest a separate `.vditor-reset` inside their container, which is why they were unaffected.

The fix adds a compound selector targeting that combined element so it scrolls itself:

```css
.vditor.fullscreen-editor .vditor-sv.vditor-reset {
  display: block;
  overflow-y: auto;
  overflow-x: hidden;
}
```

Higher specificity than the `overflow: hidden` group, so the sv/raw pane resolves to `overflow-y: auto`. Non-fullscreen editing and IR/WYSIWYG are untouched.

The repo has no CSS/DOM test harness, so I checked this with a small standalone cascade resolver that parses `vditor.css` and computes the effective `overflow-y` for the fullscreen `pre.vditor-sv.vditor-reset`: with the fix it resolves to `auto`, and after stripping the added rule it goes back to `hidden`, confirming the checker tracks the actual bug and not just my edit.