### PR TITLE
build(flatpak): publish a Flatpak bundle on release

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -246,6 +246,17 @@ jobs:
           prerelease: ${{ github.event.inputs.is-test == 'true' }}
           includeUpdaterJson: ${{ github.event.inputs.is-test != 'true' }}
 
+      # The Flatpak job repackages this .deb instead of rebuilding from source,
+      # so it has to be handed over as an artifact in both test and release mode.
+      - name: Upload Linux .deb for Flatpak job
+        if: matrix.platform == 'ubuntu-22.04'
+        uses: actions/upload-artifact@v4
+        with:
+          name: blinko-linux-deb-${{ needs.set-version.outputs.version }}
+          path: app/src-tauri/target/release/bundle/deb/*.deb
+          retention-days: 1
+          if-no-files-found: error
+
       - name: Upload test artifacts
         if: github.event.inputs.is-test == 'true'
         uses: actions/upload-artifact@v4
@@ -389,6 +400,110 @@ jobs:
         with:
           name: blinko-test-android-${{ needs.set-version.outputs.version }}
           path: app/src-tauri/gen/android/app/build/outputs/apk/universal/release/Blinko_${{ needs.set-version.outputs.version }}_universal.apk
+          retention-days: 7
+
+  # Flatpak Build Task
+  #
+  # Repackages the Linux .deb from publish-desktop against org.gnome.Platform.
+  # Unlike the AppImage, this does NOT bundle WebKitGTK: the runtime supplies
+  # WebKitGTK together with a matching GL stack, which is what stops the
+  # "Could not create default EGL display: EGL_BAD_PARAMETER" blank-window
+  # failure seen on distros whose Mesa is newer than the ubuntu-22.04 builder's.
+  publish-flatpak:
+    needs: [set-version, publish-desktop]
+    if: always() && !cancelled() && needs.publish-desktop.result == 'success'
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      # ubuntu-24.04, not 22.04: 22.04's flatpak-builder is 1.2, which invokes
+      # `appstream-compose` from appstream-glib, and current GNOME SDKs ship only
+      # `appstreamcli compose`. 24.04 has flatpak-builder 1.4.x, which uses the
+      # latter. Running it natively (rather than the Flathub-packaged
+      # org.flatpak.Builder) also avoids the builder sandbox being unable to see
+      # runtimes installed in the host's user installation.
+      - name: Install Flatpak tooling
+        run: |
+          # GitHub's 24.04 image restricts unprivileged user namespaces via
+          # AppArmor, which bubblewrap (and therefore flatpak-builder) needs.
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+          sudo apt-get update
+          sudo apt-get install -y flatpak flatpak-builder desktop-file-utils
+          flatpak-builder --version
+          flatpak remote-add --if-not-exists --user \
+            flathub https://flathub.org/repo/flathub.flatpakrepo
+          flatpak install --user -y --noninteractive \
+            flathub org.gnome.Platform//50 org.gnome.Sdk//50
+
+      - name: Cache flatpak-builder state
+        if: github.event.inputs.disable-all-cache != 'true'
+        uses: actions/cache@v4
+        with:
+          path: .flatpak-builder
+          key: flatpak-builder-${{ runner.os }}-${{ hashFiles('flatpak/space.blinko.Blinko.yml') }}
+          restore-keys: flatpak-builder-${{ runner.os }}-
+
+      - name: Download Linux .deb
+        uses: actions/download-artifact@v4
+        with:
+          name: blinko-linux-deb-${{ needs.set-version.outputs.version }}
+          path: flatpak/
+
+      - name: Stage .deb and sync AppStream version
+        run: |
+          set -euo pipefail
+          cd flatpak
+          ls -la *.deb
+          mv -- *.deb blinko.deb
+          # Keep <releases> in step with the version actually being shipped so
+          # the bundle's AppStream data is not stale in software centres.
+          python3 - "${{ needs.set-version.outputs.version }}" <<'PY'
+          import datetime, re, sys
+          version = sys.argv[1].lstrip('v')
+          path = 'space.blinko.Blinko.metainfo.xml'
+          today = datetime.date.today().isoformat()
+          xml = open(path, encoding='utf-8').read()
+          xml = re.sub(
+              r'<releases>.*?</releases>',
+              f'<releases>\n    <release version="{version}" date="{today}"/>\n  </releases>',
+              xml,
+              flags=re.S,
+          )
+          open(path, 'w', encoding='utf-8').write(xml)
+          print(f'metainfo release set to {version} ({today})')
+          PY
+
+      - name: Validate desktop entry
+        run: desktop-file-validate flatpak/space.blinko.Blinko.desktop
+
+      - name: Build Flatpak bundle
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.set-version.outputs.version }}"
+          flatpak-builder --user --force-clean --disable-rofiles-fuse \
+            --repo=flatpak-repo flatpak-build flatpak/space.blinko.Blinko.yml
+          flatpak build-bundle flatpak-repo \
+            "Blinko_${VERSION}_x86_64.flatpak" space.blinko.Blinko \
+            --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
+          ls -lh "Blinko_${VERSION}_x86_64.flatpak"
+
+      - name: Upload Flatpak to Release
+        if: github.event.inputs.is-test != 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: Blinko_${{ needs.set-version.outputs.version }}_x86_64.flatpak
+          tag_name: ${{ needs.set-version.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Flatpak as artifact (Test Mode)
+        if: github.event.inputs.is-test == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: blinko-test-flatpak-${{ needs.set-version.outputs.version }}
+          path: Blinko_${{ needs.set-version.outputs.version }}_x86_64.flatpak
           retention-days: 7
 
   # Generate changelog after all builds are complete

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,9 @@ dev-dist
 .claude/settings.local.json
 target
 server/public
+# Flatpak build artifacts
+flatpak/blinko.deb
+flatpak-build/
+flatpak-repo/
+.flatpak-builder/
+*.flatpak

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -1,0 +1,116 @@
+# Flatpak packaging
+
+Builds the Blinko desktop app as a Flatpak, published as a `.flatpak` bundle on
+every release by the `publish-flatpak` job in
+[`app-release.yml`](../.github/workflows/app-release.yml).
+
+## Why
+
+The AppImage bundles its own copy of WebKitGTK, taken from the `ubuntu-22.04`
+runner that builds it. WebKitGTK talks directly to EGL/Mesa, so a bundled copy is
+pinned to the graphics stack of the build machine. On a host with a newer Mesa,
+WebKit's renderer cannot initialise EGL:
+
+```
+Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
+```
+
+The window opens but stays blank white. The binary's `RUNPATH` is
+`$ORIGIN/../lib`, so the bundled copy wins even with `LD_LIBRARY_PATH` unset,
+and the usual escape hatches (`WEBKIT_DISABLE_DMABUF_RENDERER`,
+`WEBKIT_DISABLE_COMPOSITING_MODE`, `GDK_BACKEND=x11`) have no effect.
+
+Flatpak fixes this structurally: `org.gnome.Platform` ships WebKitGTK **and** the
+matching GL stack as one unit, so the two can never disagree.
+
+## What gets built
+
+The manifest repackages the `.deb` from the same release rather than rebuilding
+from source — a Tauri build needs network access for cargo/bun, which
+flatpak-builder's sandbox does not allow. The `.deb` is just the binary, a
+desktop entry and icons, so unpacking it is cheap and keeps the Flatpak
+byte-identical to the `.deb` we already ship.
+
+A few libraries are built because the runtime does not carry them:
+
+| Module | Why |
+| --- | --- |
+| `intltool` | Build-time only: `libdbusmenu`'s configure requires it and the SDK does not ship it. Cleaned out of the final app. |
+| `libdbusmenu` | Dependency of libayatana-appindicator. |
+| `ayatana-ido` | Dependency of libayatana-indicator. |
+| `libayatana-indicator` | Dependency of libayatana-appindicator. |
+| `libayatana-appindicator` | System tray. Blinko `dlopen()`s `libayatana-appindicator3.so.1`; without it the app runs but has no tray icon. |
+| `xdotool` (3.x) | Provides `libxdo.so.3`, a hard `DT_NEEDED` of the binary. Pinned to 3.x because 4.x installs `libxdo.so.4`. |
+
+`libdbusmenu` needs one workaround: it declares the `HAVE_VALGRIND` automake
+conditional inside its `--enable-tests` block, so building with `--disable-tests`
+leaves the conditional undefined and configure aborts. The manifest passes
+`HAVE_VALGRIND_TRUE`/`HAVE_VALGRIND_FALSE` directly to work around it.
+
+Everything else — GTK 3, WebKitGTK 4.1, libsoup 3, cairo, gdk-pixbuf — comes
+from the runtime.
+
+## Building locally
+
+```bash
+./flatpak/build-local.sh          # latest published .deb
+./flatpak/build-local.sh 1.8.8    # a specific release
+BLINKO_DEB=app/src-tauri/target/release/bundle/deb/Blinko_1.8.8_amd64.deb \
+  ./flatpak/build-local.sh        # a .deb you just built
+```
+
+Then:
+
+```bash
+flatpak install --user -y Blinko_local_x86_64.flatpak
+flatpak run space.blinko.Blinko
+```
+
+Verified by installing the bundle this workflow produces on Arch Linux (Mesa
+26.1, AMD Radeon 840M, KDE Wayland) — the same machine where the AppImage shows
+the blank white window. Against `org.gnome.Platform//50` the app renders, the
+system tray initialises, and no EGL error appears.
+
+## Mixed-DPI: window buttons may not respond
+
+On a multi-monitor setup where the screens have **different scale factors**
+(e.g. an external display at 1.0 next to a laptop panel at 1.35), the window's
+titlebar buttons can be drawn in one place while their clickable region sits in
+another, so close/minimize/maximize appear dead. The window is fine otherwise
+and the compositor can still minimize or close it programmatically.
+
+This is a GTK3/WebKitGTK-under-Wayland scaling issue rather than anything
+specific to Flatpak — the same binary shows it outside the sandbox — so the
+manifest deliberately does **not** force XWayland on everyone. Running under
+XWayland fixes it, at the cost of blurrier rendering on HiDPI screens, so it is
+left as an opt-in for affected users:
+
+```bash
+flatpak override --user --socket=x11 --nosocket=wayland \
+  --env=GDK_BACKEND=x11 space.blinko.Blinko
+```
+
+Undo with:
+
+```bash
+flatpak override --user --reset space.blinko.Blinko
+```
+
+## Known limitations
+
+- **The built-in updater does not work inside Flatpak.** A sandboxed app cannot
+  rewrite `/app`, so the Tauri updater will fail if it tries to self-update.
+  Flatpak users update through `flatpak update`. Gating the update check behind
+  an environment variable set in `finish-args` would be a good follow-up.
+- **x86_64 only**, matching the Linux `.deb` the release pipeline produces.
+- **Not yet on Flathub.** This job produces a downloadable bundle. A Flathub
+  submission additionally needs `<screenshots>` in
+  `space.blinko.Blinko.metainfo.xml` and a separate `flathub/space.blinko.Blinko`
+  repository.
+
+## App ID
+
+`space.blinko.Blinko`, derived from the project's own domain (`blinko.space`).
+This intentionally differs from the Tauri identifier `com.blinko.app`, which is
+not a domain the project controls and so would not be accepted by Flathub. The
+Tauri identifier still determines the app's data directory inside the sandbox.

--- a/flatpak/build-local.sh
+++ b/flatpak/build-local.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Build (and optionally install) the Blinko Flatpak locally.
+#
+#   ./flatpak/build-local.sh              # use the latest published .deb
+#   ./flatpak/build-local.sh 1.8.8        # use a specific released version
+#   BLINKO_DEB=/path/to/x.deb ./flatpak/build-local.sh   # use a local build
+#
+# Requires: flatpak, curl.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$HERE")"
+APP_ID="space.blinko.Blinko"
+RUNTIME_VERSION="50"
+MANIFEST="$HERE/$APP_ID.yml"
+
+for tool in flatpak curl; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "error: '$tool' is required but not installed" >&2
+    exit 1
+  }
+done
+
+# --- obtain a .deb -----------------------------------------------------------
+if [[ -n "${BLINKO_DEB:-}" ]]; then
+  echo "==> Using local .deb: $BLINKO_DEB"
+  cp -- "$BLINKO_DEB" "$HERE/blinko.deb"
+else
+  VERSION="${1:-}"
+  if [[ -z "$VERSION" ]]; then
+    echo "==> Resolving latest release..."
+    VERSION="$(curl -fsSL https://api.github.com/repos/blinkospace/blinko/releases/latest \
+      | grep -m1 '"tag_name"' | cut -d'"' -f4)"
+  fi
+  VERSION="${VERSION#v}"
+  URL="https://github.com/blinkospace/blinko/releases/download/${VERSION}/Blinko_${VERSION}_amd64.deb"
+  echo "==> Downloading $URL"
+  curl -fSL --progress-bar -o "$HERE/blinko.deb" "$URL"
+fi
+
+# --- toolchain ---------------------------------------------------------------
+# org.flatpak.Builder is used rather than a distro flatpak-builder so this
+# matches CI exactly. Older flatpak-builder releases call `appstream-compose`,
+# which current GNOME SDKs no longer ship.
+echo "==> Ensuring builder, GNOME $RUNTIME_VERSION runtime and SDK are present"
+flatpak remote-add --if-not-exists --user \
+  flathub https://flathub.org/repo/flathub.flatpakrepo
+flatpak install --user -y --noninteractive flathub org.flatpak.Builder \
+  "org.gnome.Platform//$RUNTIME_VERSION" "org.gnome.Sdk//$RUNTIME_VERSION"
+
+# --- build -------------------------------------------------------------------
+cd "$REPO_ROOT"
+echo "==> Building $APP_ID"
+flatpak run org.flatpak.Builder --user --force-clean --disable-rofiles-fuse \
+  --repo=flatpak-repo flatpak-build "$MANIFEST"
+
+BUNDLE="Blinko_local_x86_64.flatpak"
+flatpak build-bundle flatpak-repo "$BUNDLE" "$APP_ID" \
+  --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
+
+echo
+echo "==> Built $BUNDLE"
+echo "    Install with: flatpak install --user -y $BUNDLE"
+echo "    Run with:     flatpak run $APP_ID"

--- a/flatpak/space.blinko.Blinko.desktop
+++ b/flatpak/space.blinko.Blinko.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Blinko
+Comment=Self-hosted, AI-powered personal note tool
+Exec=Blinko %U
+Icon=space.blinko.Blinko
+Terminal=false
+Categories=Utility;TextEditor;
+Keywords=notes;note-taking;markdown;ai;self-hosted;memo;
+StartupNotify=true
+StartupWMClass=Blinko

--- a/flatpak/space.blinko.Blinko.metainfo.xml
+++ b/flatpak/space.blinko.Blinko.metainfo.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>space.blinko.Blinko</id>
+
+  <name>Blinko</name>
+  <summary>Self-hosted AI note tool</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+
+  <developer id="space.blinko">
+    <name>Blinko Space</name>
+  </developer>
+
+  <description>
+    <p>
+      Blinko is an open-source, self-hosted personal note tool that prioritises
+      privacy. Capture thoughts the moment they occur, then let AI-powered
+      retrieval find them again later.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>Instant capture of notes and ideas in Markdown</li>
+      <li>AI-assisted search and retrieval across your own notes</li>
+      <li>Self-hosted: your data stays on infrastructure you control</li>
+      <li>Tags, comments and attachments for organising notes</li>
+      <li>Works with any Blinko server deployment</li>
+    </ul>
+    <p>
+      This desktop application connects to a Blinko server, which you deploy
+      yourself. A server endpoint is required on first launch.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">space.blinko.Blinko.desktop</launchable>
+
+  <url type="homepage">https://blinko.space</url>
+  <url type="bugtracker">https://github.com/blinkospace/blinko/issues</url>
+  <url type="vcs-browser">https://github.com/blinkospace/blinko</url>
+
+  <categories>
+    <category>Utility</category>
+    <category>TextEditor</category>
+  </categories>
+
+  <supports>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+  </supports>
+
+  <content_rating type="oars-1.1"/>
+
+  <!--
+    NOTE: Flathub submission additionally requires at least one <screenshots>
+    entry pointing at a stable, publicly hosted image URL. Add them here before
+    submitting to Flathub; they are not needed to build the bundle in CI.
+  -->
+
+  <releases>
+    <release version="1.8.8" date="2026-06-20"/>
+  </releases>
+</component>

--- a/flatpak/space.blinko.Blinko.yml
+++ b/flatpak/space.blinko.Blinko.yml
@@ -1,0 +1,164 @@
+# Flatpak manifest for Blinko (desktop / Tauri build).
+#
+# This repackages the .deb produced by `tauri-action` rather than rebuilding
+# from source: the Tauri build needs network access for cargo/bun, which is not
+# available inside a flatpak-builder sandbox. The .deb is a plain tarball
+# containing the binary, a .desktop file and icons, so unpacking it is cheap and
+# keeps the Flatpak byte-identical to the .deb we already ship.
+#
+# The important property of this build is that WebKitGTK comes from
+# org.gnome.Platform instead of being bundled. A bundled WebKitGTK is pinned to
+# the graphics stack of the machine that built it, which is why the AppImage
+# fails with "Could not create default EGL display: EGL_BAD_PARAMETER" on hosts
+# with a newer Mesa than the Ubuntu 22.04 builder. The runtime ships WebKitGTK
+# and its matching GL stack together, so that mismatch cannot occur.
+#
+# Build locally with: ./flatpak/build-local.sh
+
+app-id: space.blinko.Blinko
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: Blinko
+
+finish-args:
+  # Display / GPU
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  # Blinko is a client for a self-hosted server, so network is mandatory.
+  - --share=network
+  # Voice notes (recording and playback).
+  - --socket=pulseaudio
+  # System tray icon (StatusNotifierItem) and desktop notifications.
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.freedesktop.Notifications
+  # Attachment downloads and note exports. File pickers go through the portal,
+  # so no broader filesystem access is required.
+  - --filesystem=xdg-download
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /share/man
+  - /share/gtk-doc
+  - /share/vala
+  - '*.a'
+  - '*.la'
+
+modules:
+  # libdbusmenu still uses intltool, which the GNOME SDK does not ship. Built
+  # here as a build-time-only dependency and cleaned out of the final app.
+  - name: intltool
+    cleanup:
+      - '*'
+    sources:
+      - type: archive
+        url: https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz
+        sha256: 67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd
+
+  # libdbusmenu -> libayatana-indicator -> libayatana-appindicator provide the
+  # system tray. Blinko dlopen()s libayatana-appindicator3.so.1 at startup; if
+  # it is absent the app still runs but silently loses its tray icon.
+  - name: libdbusmenu
+    buildsystem: autotools
+    build-options:
+      cflags: -Wno-error -Wno-deprecated-declarations
+    config-opts:
+      - --with-gtk=3
+      - --disable-dumper
+      - --disable-static
+      - --disable-tests
+      - --disable-gtk-doc
+      - --disable-vala
+      - --enable-introspection=no
+      # libdbusmenu 16.04 defines the HAVE_VALGRIND automake conditional inside
+      # its `AS_IF([test "x$enable_tests" != "xno"], ...)` block, so
+      # --disable-tests leaves it undefined and configure aborts with
+      # 'conditional "HAVE_VALGRIND" was never defined'. Supply it directly;
+      # '#' is automake's "condition is false" marker.
+      - 'HAVE_VALGRIND_TRUE=#'
+      - 'HAVE_VALGRIND_FALSE='
+    sources:
+      - type: archive
+        url: https://launchpad.net/libdbusmenu/16.04/16.04.0/+download/libdbusmenu-16.04.0.tar.gz
+        sha256: b9cc4a2acd74509435892823607d966d424bd9ad5d0b00938f27240a1bfa878a
+
+  - name: ayatana-ido
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_INSTALL_LIBDIR=lib
+      - -DENABLE_TESTS=OFF
+    sources:
+      - type: archive
+        url: https://github.com/AyatanaIndicators/ayatana-ido/archive/refs/tags/0.10.4.tar.gz
+        sha256: bd59abd5f1314e411d0d55ce3643e91cef633271f58126be529de5fb71c5ab38
+
+  - name: libayatana-indicator
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_INSTALL_LIBDIR=lib
+      - -DENABLE_TESTS=OFF
+      - -DFLAVOUR_GTK3=ON
+    sources:
+      - type: archive
+        url: https://github.com/AyatanaIndicators/libayatana-indicator/archive/refs/tags/0.9.5.tar.gz
+        sha256: 73d71c908b803f12e4a5ecd8392511b58afbdd0c82ad7909611a17bb7847c5c8
+
+  - name: libayatana-appindicator
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_INSTALL_LIBDIR=lib
+      - -DENABLE_TESTS=OFF
+      - -DENABLE_GTKDOC=OFF
+      - -DENABLE_BINDINGS_VALA=OFF
+      - -DENABLE_BINDINGS_MONO=OFF
+      - -DFLAVOUR_GTK3=ON
+    sources:
+      - type: archive
+        url: https://github.com/AyatanaIndicators/libayatana-appindicator/archive/refs/tags/0.6.0.tar.gz
+        sha256: 23be92ad8eb9625ce93b23b14f82f3cf88a4970c31d48581945ddfbac0441d06
+
+  # libxdo.so.3 is a hard DT_NEEDED of the Blinko binary (global shortcuts), and
+  # the GNOME runtime does not ship it. Pin the 3.x series: xdotool 4.x installs
+  # libxdo.so.4 and the binary would fail to start.
+  - name: xdotool
+    buildsystem: simple
+    build-commands:
+      - make PREFIX=/app LIBDIR=/app/lib install
+    sources:
+      - type: archive
+        url: https://github.com/jordansissel/xdotool/archive/refs/tags/v3.20211022.1.tar.gz
+        sha256: 82b15a944a5e82fee15e0f6116bd9f642bc3d0bb6989fc0ca5ad9dfe35de0847
+
+  - name: blinko
+    buildsystem: simple
+    build-commands:
+      # .deb is an ar archive wrapping data.tar.*
+      - ar x blinko.deb
+      - tar -xf data.tar.*
+      - install -Dm755 usr/bin/Blinko /app/bin/Blinko
+      - install -Dm644 space.blinko.Blinko.desktop /app/share/applications/space.blinko.Blinko.desktop
+      - install -Dm644 space.blinko.Blinko.metainfo.xml /app/share/metainfo/space.blinko.Blinko.metainfo.xml
+      # Icons must be renamed to the app-id for the desktop to resolve them.
+      - |
+        for size in 32x32 128x128 256x256@2; do
+          src="usr/share/icons/hicolor/$size/apps/Blinko.png"
+          [ -f "$src" ] && install -Dm644 "$src" \
+            "/app/share/icons/hicolor/$size/apps/space.blinko.Blinko.png"
+        done
+        exit 0
+    sources:
+      # Produced by the tauri-action build earlier in the release workflow and
+      # copied here as flatpak/blinko.deb. See build-local.sh to fetch a
+      # published .deb instead when building by hand.
+      - type: file
+        path: blinko.deb
+      - type: file
+        path: space.blinko.Blinko.desktop
+      - type: file
+        path: space.blinko.Blinko.metainfo.xml


### PR DESCRIPTION
## Summary

Adds a `publish-flatpak` job to the release workflow that ships a Flatpak bundle alongside the existing `.deb`, `.rpm` and AppImage artifacts.

This exists because **the AppImage does not start on distros with a newer Mesa than the `ubuntu-22.04` runner** — the window opens and stays blank white.

## The problem

The AppImage bundles its own copy of WebKitGTK, taken from the runner that built it. WebKitGTK talks directly to EGL/Mesa, so a bundled copy is pinned to the graphics stack of the build machine. On a host with a newer Mesa, WebKit's renderer cannot initialise EGL and aborts:

```
Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
```

The app process stays alive, so it looks like a rendering bug rather than a missing library. Two details make this hard for users to work around:

- The binary's `RUNPATH` is `$ORIGIN/../lib`, so the bundled WebKitGTK wins even with `LD_LIBRARY_PATH` unset.
- The usual escape hatches — `WEBKIT_DISABLE_DMABUF_RENDERER`, `WEBKIT_DISABLE_COMPOSITING_MODE`, `GDK_BACKEND=x11` — have no effect, because the problem is which WebKitGTK is loaded, not how it renders.

Reproduced on Arch Linux (Mesa 26.1, AMD Radeon 840M, KDE Wayland). Deleting the bundled `libwebkit2gtk-4.1.so.0` so the system copy loads fixes it immediately, which confirms the diagnosis.

## Why Flatpak fixes it structurally

`org.gnome.Platform` ships WebKitGTK **and** the matching GL stack as a single versioned unit, so the two cannot disagree. This is not a workaround that needs maintaining — the class of bug cannot occur.

## What this adds

| File | Purpose |
| --- | --- |
| `flatpak/space.blinko.Blinko.yml` | Manifest |
| `flatpak/space.blinko.Blinko.desktop` | Desktop entry (fixes empty `Categories`, adds `StartupWMClass`) |
| `flatpak/space.blinko.Blinko.metainfo.xml` | AppStream metadata |
| `flatpak/build-local.sh` | Reproduce the CI build locally |
| `flatpak/README.md` | Rationale and troubleshooting |

Workflow changes: `publish-desktop` uploads its Linux `.deb` as an artifact, and the new `publish-flatpak` job consumes it, builds, and attaches `Blinko_<version>_x86_64.flatpak` to the release. It follows the existing `softprops/action-gh-release` / test-mode-artifact pattern used by `publish-android`, and does not gate any existing job.

The manifest **repackages the `.deb` this pipeline already builds** rather than rebuilding from source — a Tauri build needs network access for cargo/bun, which flatpak-builder's sandbox does not allow. The `.deb` is only the binary, a desktop entry and icons, so the Flatpak stays byte-identical to the `.deb`.

Three libraries are built because the runtime does not carry them:

| Module | Why |
| --- | --- |
| `xdotool` (3.x) | Provides `libxdo.so.3`, a hard `DT_NEEDED` of the binary. Pinned to 3.x — 4.x installs `libxdo.so.4`. |
| `libdbusmenu` → `ayatana-ido` → `libayatana-indicator` → `libayatana-appindicator` | System tray. Blinko `dlopen()`s `libayatana-appindicator3.so.1`. |
| `intltool` | Build-time only; `libdbusmenu`'s configure requires it. Cleaned from the final app. |

Everything else — GTK 3, WebKitGTK 4.1, libsoup 3, cairo, gdk-pixbuf — comes from the runtime. Result: **12 MB**, against the AppImage's 96 MB.

## Verification

CI green on a fork: `publish-flatpak` succeeded end to end and produced a 12.1 MB bundle. `publish-desktop` passed on all three platforms, so the `.deb` handoff works. (`publish-android` fails on the fork only because it has no `UPLOAD_KEYSTORE` secret — unrelated to this change.)

That bundle was then installed and launched on the same Arch machine where the AppImage shows the blank window: the app renders, the system tray initialises, and no EGL error appears.

## Scope and known limitations

- **This does not replace the AppImage.** It adds a fourth Linux artifact. If you would rather fix the AppImage directly, deleting the bundled `libwebkit2gtk-4.1.so.0`, `libjavascriptcoregtk-4.1.so.0` and `usr/lib/x86_64-linux-gnu/webkit2gtk-4.1/` from the AppDir before `appimagetool` runs is sufficient — `RUNPATH` then falls through to the system copy, and the helper-process path is compiled into whichever library loads, so it self-corrects. That is a complementary change, not an alternative.
- **The built-in updater will not work inside Flatpak** — a sandboxed app cannot rewrite `/app`. Flatpak users update via `flatpak update`. Gating the update check behind an environment variable set in `finish-args` would be a good follow-up.
- **x86_64 only**, matching the Linux `.deb` the pipeline produces.
- **Not a Flathub submission.** This produces a downloadable bundle. Flathub would additionally need `<screenshots>` in the metainfo and a separate `flathub/space.blinko.Blinko` repository.
- **App ID is `space.blinko.Blinko`**, from the project's own domain, rather than the Tauri identifier `com.blinko.app` — Flathub requires an ID matching a domain the project controls. The Tauri identifier still determines the data directory inside the sandbox.
- On multi-monitor setups with **differing scale factors**, the titlebar buttons can be drawn away from their clickable region. This is a GTK3/WebKitGTK Wayland scaling issue that also affects the non-Flatpak build, so the manifest deliberately does not force XWayland on everyone; `flatpak/README.md` records the opt-in override for affected users.

## Notes for reviewers

Four environment details are pinned deliberately, each found by a failing CI run. They look arbitrary but are load-bearing:

- **Runtime is GNOME 50.** GNOME 48 reached end-of-life on 2026-03-24 and Flathub no longer lists it. `flatpak install` only *warns*, so it is easy to ship against an unsupported runtime by accident.
- **`CMAKE_INSTALL_LIBDIR=lib` is pinned** on every CMake module. Newer flatpak-builder passes it, older does not, and CMake's `GNUInstallDirs` otherwise picks `lib64` on x86_64 — leaving `pkg-config` unable to find `libayatana-ido3-0.4`.
- **The job runs on `ubuntu-24.04`.** 22.04's flatpak-builder is 1.2, which invokes `appstream-compose` from appstream-glib; current GNOME SDKs ship only `appstreamcli compose`. 24.04 has 1.4.x. GitHub's 24.04 image restricts unprivileged user namespaces via AppArmor, so the job lifts that first or bubblewrap cannot start.
- **flatpak-builder runs natively**, not as the Flathub-packaged `org.flatpak.Builder`, whose sandbox could not see runtimes installed in the runner's user installation.

## How to test

Locally, against a published or locally built `.deb`:

```bash
./flatpak/build-local.sh                    # latest published .deb
BLINKO_DEB=path/to/Blinko_x.y.z_amd64.deb \
  ./flatpak/build-local.sh                  # a .deb you just built

flatpak install --user -y Blinko_local_x86_64.flatpak
flatpak run space.blinko.Blinko
```

In CI, run the workflow with **Test Mode** enabled — no release is created and the bundle is uploaded as a workflow artifact.
