### PR TITLE
fix: restore broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ If you find Blinko valuable, consider supporting us! Your contribution will enab
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=blinko-space/blinko&type=Date)](https://star-history.com/#blinko-space/blinko&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=blinko-space/blinko&type=Date)](https://star-history.dera.page/#blinko-space/blinko&Date)
 
 <div align="center">
     <a href="https://next.ossinsight.io/widgets/official/compose-last-28-days-stats?repo_id=877230294" target="_blank" style="display: block" align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -89,7 +89,7 @@ curl -s https://raw.githubusercontent.com/blinko-space/blinko/main/install.sh | 
 
 ## Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=blinko-space/blinko&type=Date)](https://star-history.com/#blinko-space/blinko&Date) 
+[![Star History Chart](https://star-history.dera.page/svg?repos=blinko-space/blinko&type=Date)](https://star-history.dera.page/#blinko-space/blinko&Date) 
 
 
 <div align="center">


### PR DESCRIPTION
The star history chart on the main README is currently broken because the original service is no longer able to fetch data through the GitHub stargazer API. This switches the chart and its link to a working instance of the same chart (star-history.dera.page), without changing any other content. The chart is again visible in both README.md and the Chinese localized version.