### PR TITLE
feat(share): show who a note is shared with / shared by

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,9 @@ dev-dist
 .claude/settings.local.json
 target
 server/public
+
+# Local tooling / editor artifacts (not part of the project)
+.vs/
+.cursorrules
+PLANNING.md
+TASK.md

--- a/app/public/locales/en/translation.json
+++ b/app/public/locales/en/translation.json
@@ -447,6 +447,8 @@
   "share-link-expired-desc": "This share has expired please contact the administrator to re-share!",
   "shared": "Shared",
   "internal-shared": "Internal Shared",
+  "shared-with": "Shared with",
+  "shared-by": "Shared by",
   "edited": "Edited",
   "move-down": "Move Down",
   "provider-id": "Provider ID",

--- a/app/public/locales/zh/translation.json
+++ b/app/public/locales/zh/translation.json
@@ -441,6 +441,8 @@
   "share-link-expired-desc": "这份共享已过期，请联系管理员重新共享！",
   "shared": "共享",
   "internal-shared": "内部共享",
+  "shared-with": "分享给",
+  "shared-by": "分享自",
   "edited": "已编辑",
   "move-down": "向下移动",
   "provider-id": "提供者ID",

--- a/app/src/components/BlinkoCard/cardHeader.tsx
+++ b/app/src/components/BlinkoCard/cardHeader.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '@/components/Common/Iconify/icons';
-import { Tooltip } from '@heroui/react';
+import { Tooltip, Avatar, AvatarGroup, Popover, PopoverTrigger, PopoverContent } from '@heroui/react';
 import { Copy } from "../Common/Copy";
 import { LeftCickMenu, ShowEditTimeModel } from "../BlinkoRightClickMenu";
 import { BlinkoStore } from '@/store/blinkoStore';
@@ -68,15 +68,41 @@ export const CardHeader = observer(({ blinkoItem, blinko, isShareMode, isExpande
           </Tooltip>
         )}
 
-        {blinkoItem.isInternalShared && (
-          <Tooltip content={t('internal-shared')} delay={1000}>
-            <div className="flex items-center gap-2">
-              <Icon
-                className="cursor-pointer "
-                icon="prime:users"
-                width={iconSize}
-                height={iconSize}
-              />
+        {/* Owner view: who this note is shared with (click to open a scrollable list) */}
+        {blinkoItem.isInternalShared && !blinkoItem.isSharedNote && !!blinkoItem.internalShares?.length && (
+          <Popover placement="bottom-start" showArrow>
+            <PopoverTrigger>
+              <div className="flex items-center cursor-pointer" onClick={(e) => e.stopPropagation()}>
+                <AvatarGroup max={3} className="[&_span]:w-5 [&_span]:h-5 [&_span]:text-[9px]">
+                  {blinkoItem.internalShares!.map((s) => (
+                    <Avatar key={s.accountId} src={s.account?.image || undefined} name={s.account?.nickname || s.account?.name} />
+                  ))}
+                </AvatarGroup>
+              </div>
+            </PopoverTrigger>
+            <PopoverContent>
+              <div className="flex flex-col gap-1.5 py-2 w-[220px] max-h-[280px] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+                <span className="text-tiny opacity-60 px-1">{t('shared-with')} ({blinkoItem.internalShares!.length})</span>
+                {blinkoItem.internalShares!.map((s) => (
+                  <div key={s.accountId} className="flex items-center gap-2 px-1">
+                    <Avatar src={s.account?.image || undefined} name={s.account?.nickname || s.account?.name} className="w-6 h-6 text-tiny shrink-0" />
+                    <span className="text-xs truncate flex-1">{s.account?.nickname || s.account?.name}</span>
+                    {s.canEdit
+                      ? <Icon icon="material-symbols:edit-outline" className="text-primary shrink-0" width="14" height="14" />
+                      : <Icon icon="material-symbols:lock-outline" className="opacity-40 shrink-0" width="14" height="14" />}
+                  </div>
+                ))}
+              </div>
+            </PopoverContent>
+          </Popover>
+        )}
+
+        {/* Recipient view: who shared this note with me */}
+        {blinkoItem.isSharedNote && blinkoItem.owner && (
+          <Tooltip content={`${t('shared-by')}: ${blinkoItem.owner.nickname || blinkoItem.owner.name}`} delay={300}>
+            <div className="flex items-center gap-1 cursor-pointer">
+              <Avatar src={blinkoItem.owner.image || undefined} name={blinkoItem.owner.nickname || blinkoItem.owner.name} className="w-5 h-5 text-tiny shrink-0" />
+              <span className={`${isExpanded ? 'text-sm' : 'text-xs'} text-desc truncate max-w-[100px]`}>{blinkoItem.owner.nickname || blinkoItem.owner.name}</span>
             </div>
           </Tooltip>
         )}

--- a/server/routerTrpc/note.ts
+++ b/server/routerTrpc/note.ts
@@ -99,6 +99,16 @@ export const noteRouter = router({
             isSharedNote: z.boolean().optional(),
             canEdit: z.boolean().optional(),
             isInternalShared: z.boolean().optional(),
+            internalShares: z.array(z.object({
+              accountId: z.number().optional(),
+              canEdit: z.boolean().optional(),
+              account: z.object({
+                id: z.number(),
+                name: z.string(),
+                nickname: z.string(),
+                image: z.string(),
+              }).nullable().optional(),
+            })).optional(),
           }),
         ),
       ),
@@ -244,14 +254,28 @@ export const noteRouter = router({
               histories: true,
             },
           },
-          internalShares: true,
+          account: {
+            select: { id: true, name: true, nickname: true, image: true },
+          },
+          internalShares: {
+            include: {
+              account: {
+                select: { id: true, name: true, nickname: true, image: true },
+              },
+            },
+          },
         },
       });
 
-      return notes.map((note) => ({
-        ...note,
-        isInternalShared: note.internalShares.length > 0,
-      }));
+      return notes.map((note) => {
+        const isOwner = note.accountId === Number(ctx.id);
+        return {
+          ...note,
+          owner: note.account,               // note author (for recipient's "shared by" view)
+          isSharedNote: !isOwner,            // this note was shared TO the current user
+          isInternalShared: note.internalShares.length > 0,
+        };
+      });
     }),
   publicList: publicProcedure
     .meta({
@@ -618,13 +642,31 @@ export const noteRouter = router({
               comments: z.number(),
               histories: z.number(),
             }),
+            owner: z.object({
+              id: z.number(),
+              name: z.string(),
+              nickname: z.string(),
+              image: z.string(),
+            }).nullable().optional(),
+            isSharedNote: z.boolean().optional(),
+            isInternalShared: z.boolean().optional(),
+            internalShares: z.array(z.object({
+              accountId: z.number().optional(),
+              canEdit: z.boolean().optional(),
+              account: z.object({
+                id: z.number(),
+                name: z.string(),
+                nickname: z.string(),
+                image: z.string(),
+              }).nullable().optional(),
+            })).optional(),
           }),
         ),
       ]),
     )
     .mutation(async function ({ input, ctx }) {
       const { id } = input;
-      return await prisma.notes.findFirst({
+      const note = await prisma.notes.findFirst({
         where: {
           id,
           OR: [
@@ -664,8 +706,26 @@ export const noteRouter = router({
             },
           },
           _count: { select: { comments: true, histories: true } },
+          account: {
+            select: { id: true, name: true, nickname: true, image: true },
+          },
+          internalShares: {
+            include: {
+              account: {
+                select: { id: true, name: true, nickname: true, image: true },
+              },
+            },
+          },
         },
       });
+      if (!note) return null;
+      const isOwner = note.accountId === Number(ctx.id);
+      return {
+        ...note,
+        owner: note.account,
+        isSharedNote: !isOwner,
+        isInternalShared: note.internalShares.length > 0,
+      };
     }),
   dailyReviewNoteList: authProcedure
     .meta({ openapi: { method: 'GET', path: '/v1/note/daily-review-list', summary: 'Query daily review note list', protect: true, tags: ['Note'] } })


### PR DESCRIPTION
## Summary

The internal-share indicator was just an icon with no user info — you
couldn't tell who a note was shared with, or who shared it with you.

## Changes

- `note.list` and `note.detail` now include the note owner and each
  internal share's account details (id, name, nickname, image).
- CardHeader shows two views:
  - **Owner view**: an avatar group of recipients (max 3 + overflow
    count). Clicking opens a scrollable Popover listing every recipient,
    each with an edit / read-only hint.
  - **Recipient view**: the author's avatar and name, "shared by" on hover.
- i18n: added `shared-with` / `shared-by` (en + zh).