### PR TITLE
Add RepoCloud one-click deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Blinko is an AI-powered card note-taking project. Designed for individuals who w
   <a href="https://www.pikapods.com/pods?run=blinko"><img src="./app/public/run-on-pikapods.svg" alt="Run on PikaPods" height="68" /></a>
   &nbsp;&nbsp;
   <a href="https://www.zimaspace.com/zimaos?utm_source=github&amp;utm_medium=referral&amp;utm_campaign=blinko_readme&amp;utm_content=zimaos_link"><img src="./app/public/run-on-zimaos.svg" alt="Run on ZimaOS" height="68" /></a>
+  &nbsp;&nbsp;
+  <a href="https://repocloud.io/details/Blinko/"><img src="https://d16t0pc4846x52.cloudfront.net/deploylobe.svg" alt="Deploy on RepoCloud" height="68" /></a>
 </p>
 
 ## 🚀Main Features


### PR DESCRIPTION
Added a RepoCloud deploy button alongside the existing PikaPods and ZimaOS buttons.

The button links to https://repocloud.io/details/Blinko/ where users can deploy Blinko with one click.